### PR TITLE
Fix for buffer overflow in OnOverlapCreatedTask

### DIFF
--- a/PhysX_3.4/Source/SimulationController/src/ScScene.cpp
+++ b/PhysX_3.4/Source/SimulationController/src/ScScene.cpp
@@ -6314,13 +6314,13 @@ void Sc::Scene::preallocateContactManagers(PxBaseTask* continuation)
 
 	{
 		//We allocate at least 1 element in this array to ensure that the onOverlapCreated functions don't go bang!
-		mPreallocatedContactManagers.reserve(totalCreatedPairs);
-		mPreallocatedShapeInteractions.reserve(totalCreatedPairs);
-		mPreallocatedInteractionMarkers.reserve(totalSuppressPairs);
+		mPreallocatedContactManagers.reserve(totalCreatedPairs + 1);
+		mPreallocatedShapeInteractions.reserve(totalCreatedPairs + 1);
+		mPreallocatedInteractionMarkers.reserve(totalSuppressPairs + 1);
 
-		mPreallocatedContactManagers.forceSize_Unsafe(totalCreatedPairs);
-		mPreallocatedShapeInteractions.forceSize_Unsafe(totalCreatedPairs);
-		mPreallocatedInteractionMarkers.forceSize_Unsafe(totalSuppressPairs);
+		mPreallocatedContactManagers.forceSize_Unsafe(totalCreatedPairs + 1);
+		mPreallocatedShapeInteractions.forceSize_Unsafe(totalCreatedPairs + 1);
+		mPreallocatedInteractionMarkers.forceSize_Unsafe(totalSuppressPairs + 1);
 				
 	}
 


### PR DESCRIPTION
After a crash occurred in our game, I found out that OnOverlapCreatedTask::runInternal could read off the end of an allocated buffer.

The local variables currentSI and currentEI are pointers into the mShapeInteractions and mInteractionMarkers buffers respectively. Whenever an item in the buffer is used by an interaction, the pointer into the buffer (currentSI or currentEI) is incremented. Once all the items in the buffer have been used, the pointer will point to the memory address directly after the buffer, so if any code dereferences the pointer, it will be reading memory out of bounds, which rarely causes problems in practice but can occasionally cause a crash.

The problem is that the call to mNPhaseCore->createRbElementInteraction on line 6232 dereferences both currentSI and currentEI, so once one of those pointers reaches the end of its buffer, this line will perform an invalid read.

My change makes the affected buffers one element larger than they need to be, so that OnOverlapCreatedTask doesn't read invalid memory. This seemed better for performance than adding a check to ensure that the memory reads are within the bounds of the buffer, and the memory overhead is negligible.

I previously had a 100% repro for a crash caused by this bug, and after making this change the crash no longer occurs.