### PR TITLE
Fix undefined behavior in PxUnionCast

### DIFF
--- a/PxShared/include/foundation/PxUnionCast.h
+++ b/PxShared/include/foundation/PxUnionCast.h
@@ -30,6 +30,9 @@
 #ifndef PXFOUNDATION_PXUNIONCAST_H
 #define PXFOUNDATION_PXUNIONCAST_H
 
+#include <cstring>
+#include <type_traits>
+
 #include "foundation/Px.h"
 
 /** \addtogroup foundation
@@ -42,17 +45,15 @@ namespace physx
 #endif
 
 template <class A, class B>
-PX_FORCE_INLINE A PxUnionCast(B b)
+PX_FORCE_INLINE A PxUnionCast(B source)
 {
-	union AB
-	{
-		AB(B bb) : _b(bb)
-		{
-		}
-		B _b;
-		A _a;
-	} u(b);
-	return u._a;
+	static_assert(std::is_trivial<A>::value, "Destination type must be trivial.");
+	static_assert(std::is_trivial<B>::value, "Source type must be trivial.");
+	A dest{};
+
+	std::memcpy(&dest, &source,
+		sizeof(dest) <= sizeof(source) ? sizeof(dest) : sizeof(source));
+	return dest;
 }
 
 #if !PX_DOXYGEN


### PR DESCRIPTION
Fixes crash in linux with a new version of clang.

The C++ standard does not define behavior of accessing a different union member from the one that was last written. std::memcpy is a defined way to accomplish the same.