### PR TITLE
Fix assert in SimpleAABBManager::updateAABBsAndBP

### DIFF
--- a/PhysX_3.4/Source/SimulationController/src/ScScene.cpp
+++ b/PhysX_3.4/Source/SimulationController/src/ScScene.cpp
@@ -2329,7 +2329,10 @@ void Sc::Scene::preRigidBodyNarrowPhase(PxBaseTask* continuation)
 			Sc::ShapeSim* shapeSim = NULL;
 			while ((shapeSim = iterator.getNext()) != NULL)
 			{
-				changedMap.growAndSet(shapeSim->getElementID());
+				if (shapeSim->isInBroadPhase())
+				{
+					changedMap.growAndSet(shapeSim->getElementID());
+				}
 			}
 
 			if (ccdTask->mNbBodies == SpeculativeCCDContactDistanceUpdateTask::MaxBodies)


### PR DESCRIPTION
If a body with speculative CCD enabled has scene query or visualization shapes, adding them to the changed handle map will result in SimpleAABBManager::updateAABBsAndBP asserting on PX_ASSERT(mGroups[handle] != Bp::FilterGroup::eINVALID);