### PR TITLE
Fixed rare crash in Vermintide 2

### DIFF
--- a/PhysX_3.4/Source/GeomUtils/src/gjk/GuEPAFacet.h
+++ b/PhysX_3.4/Source/GeomUtils/src/gjk/GuEPAFacet.h
@@ -46,7 +46,7 @@
 
 namespace physx
 {
-#define MaxEdges 32
+#define MaxEdges 64
 #define MaxFacets 64
 #define MaxSupportPoints 64
 


### PR DESCRIPTION
We had a very rare crash in Vermintide 2, where we indexed past 32 MaxEdges, this change fixed it. It would be really nice to merge it to upstream PhysX, so we don't have to apply it manually every time we plan to update PhysX