### PR TITLE
Optimized VS2015 x64 compilation flags

### DIFF
--- a/PhysX_3.4/Source/compiler/vc14win64/LowLevel.vcxproj
+++ b/PhysX_3.4/Source/compiler/vc14win64/LowLevel.vcxproj
@@ -1,378 +1,387 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{2A1F82AF-85E5-26A0-BFE0-1F8D0006DA7A}</ProjectGuid>
-		<RootNamespace>LowLevel</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevel/debug\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)DEBUG</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/headers;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../GeomUtils/src;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevel/checked\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)CHECKED</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/headers;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../GeomUtils/src;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevel/profile\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)PROFILE</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/headers;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../GeomUtils/src;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevel/release\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/headers;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../GeomUtils/src;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\LowLevel\API\src\px_globals.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevel\API\include\PxsMaterialCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\API\include\PxsMaterialManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\API\include\PxvConfig.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\API\include\PxvContext.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\API\include\PxvDynamics.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\API\include\PxvGeometry.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\API\include\PxvGlobals.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\API\include\PxvManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\API\include\PxvSimStats.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\LowLevel\software\src\PxsCCD.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\software\src\PxsContactManager.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\software\src\PxsContext.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\software\src\PxsDefaultMemoryManager.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\software\src\PxsIslandSim.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\software\src\PxsMaterialCombiner.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\software\src\PxsNphaseImplementationContext.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\software\src\PxsSimpleIslandManager.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsBodySim.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsCCD.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsContactManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsContactManagerState.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsContext.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsDefaultMemoryManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsHeapMemoryAllocator.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsIncrementalConstraintPartitioning.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsIslandManagerTypes.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsIslandSim.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsKernelWrangler.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsMaterialCombiner.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsMemoryManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsNphaseImplementationContext.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsRigidBody.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsShapeSim.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsSimpleIslandManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsSimulationController.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxsTransformCache.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\software\include\PxvNphaseImplementationContext.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\LowLevel\common\src\collision\PxcContact.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcContactCache.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcContactMethodImpl.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcMaterialHeightField.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcMaterialMesh.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcMaterialMethodImpl.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcMaterialShape.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcNpBatch.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcNpCacheStreamPair.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcNpContactPrepShared.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcNpMemBlockPool.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcNpThreadContext.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevel\common\include\collision\PxcContactMethodImpl.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcCCDStateStreamPair.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcConstraintBlockStream.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcContactCache.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcMaterialMethodImpl.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpBatch.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpCache.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpCacheStreamPair.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpContactPrepShared.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpMemBlockPool.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpThreadContext.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpWorkUnit.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcRigidBody.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevel\common\include\utils\PxcScratchAllocator.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevel\common\include\utils\PxcThreadCoherentCache.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{2A1F82AF-85E5-26A0-BFE0-1F8D0006DA7A}</ProjectGuid>
+    <RootNamespace>LowLevel</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevel/debug\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)DEBUG</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/headers;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../GeomUtils/src;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevel/checked\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)CHECKED</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/headers;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../GeomUtils/src;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevel/profile\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)PROFILE</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/headers;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../GeomUtils/src;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevel/release\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/headers;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../GeomUtils/src;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\LowLevel\API\src\px_globals.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevel\API\include\PxsMaterialCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\API\include\PxsMaterialManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\API\include\PxvConfig.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\API\include\PxvContext.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\API\include\PxvDynamics.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\API\include\PxvGeometry.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\API\include\PxvGlobals.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\API\include\PxvManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\API\include\PxvSimStats.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\LowLevel\software\src\PxsCCD.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\software\src\PxsContactManager.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\software\src\PxsContext.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\software\src\PxsDefaultMemoryManager.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\software\src\PxsIslandSim.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\software\src\PxsMaterialCombiner.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\software\src\PxsNphaseImplementationContext.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\software\src\PxsSimpleIslandManager.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsBodySim.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsCCD.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsContactManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsContactManagerState.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsContext.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsDefaultMemoryManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsHeapMemoryAllocator.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsIncrementalConstraintPartitioning.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsIslandManagerTypes.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsIslandSim.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsKernelWrangler.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsMaterialCombiner.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsMemoryManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsNphaseImplementationContext.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsRigidBody.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsShapeSim.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsSimpleIslandManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsSimulationController.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxsTransformCache.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\software\include\PxvNphaseImplementationContext.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\LowLevel\common\src\collision\PxcContact.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcContactCache.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcContactMethodImpl.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcMaterialHeightField.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcMaterialMesh.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcMaterialMethodImpl.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcMaterialShape.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcNpBatch.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcNpCacheStreamPair.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcNpContactPrepShared.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcNpMemBlockPool.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevel\common\src\pipeline\PxcNpThreadContext.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevel\common\include\collision\PxcContactMethodImpl.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcCCDStateStreamPair.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcConstraintBlockStream.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcContactCache.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcMaterialMethodImpl.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpBatch.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpCache.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpCacheStreamPair.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpContactPrepShared.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpMemBlockPool.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpThreadContext.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcNpWorkUnit.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\common\include\pipeline\PxcRigidBody.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevel\common\include\utils\PxcScratchAllocator.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevel\common\include\utils\PxcThreadCoherentCache.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PhysX_3.4/Source/compiler/vc14win64/LowLevelAABB.vcxproj
+++ b/PhysX_3.4/Source/compiler/vc14win64/LowLevelAABB.vcxproj
@@ -1,264 +1,273 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{3059DE83-BFC9-5922-86A0-A9D1091E5EE0}</ProjectGuid>
-		<RootNamespace>LowLevelAABB</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelAABB/debug\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)DEBUG</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../Common/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelAABB/src;./../../GpuBroadPhase/include;./../../GpuBroadPhase/src;./../../LowLevelAABB/windows/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelAABB/checked\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)CHECKED</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../Common/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelAABB/src;./../../GpuBroadPhase/include;./../../GpuBroadPhase/src;./../../LowLevelAABB/windows/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelAABB/profile\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)PROFILE</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../Common/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelAABB/src;./../../GpuBroadPhase/include;./../../GpuBroadPhase/src;./../../LowLevelAABB/windows/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelAABB/release\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../Common/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelAABB/src;./../../GpuBroadPhase/include;./../../GpuBroadPhase/src;./../../LowLevelAABB/windows/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevelAABB\include\BpAABBManagerTasks.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelAABB\include\BpBroadPhase.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelAABB\include\BpBroadPhaseUpdate.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelAABB\include\BpSimpleAABBManager.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevelAABB\src\BpBroadPhaseMBP.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelAABB\src\BpBroadPhaseMBPCommon.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelAABB\src\BpBroadPhaseSap.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelAABB\src\BpBroadPhaseSapAux.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelAABB\src\BpMBPTasks.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelAABB\src\BpSAPTasks.h">
-		</ClInclude>
-		<ClCompile Include="..\..\LowLevelAABB\src\BpBroadPhase.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelAABB\src\BpBroadPhaseMBP.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelAABB\src\BpBroadPhaseSap.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelAABB\src\BpBroadPhaseSapAux.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelAABB\src\BpMBPTasks.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelAABB\src\BpSAPTasks.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelAABB\src\BpSimpleAABBManager.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{3059DE83-BFC9-5922-86A0-A9D1091E5EE0}</ProjectGuid>
+    <RootNamespace>LowLevelAABB</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelAABB/debug\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)DEBUG</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../Common/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelAABB/src;./../../GpuBroadPhase/include;./../../GpuBroadPhase/src;./../../LowLevelAABB/windows/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelAABB/checked\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)CHECKED</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../Common/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelAABB/src;./../../GpuBroadPhase/include;./../../GpuBroadPhase/src;./../../LowLevelAABB/windows/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelAABB/profile\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)PROFILE</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../Common/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelAABB/src;./../../GpuBroadPhase/include;./../../GpuBroadPhase/src;./../../LowLevelAABB/windows/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelAABB/release\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../Common/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelAABB/src;./../../GpuBroadPhase/include;./../../GpuBroadPhase/src;./../../LowLevelAABB/windows/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevelAABB\include\BpAABBManagerTasks.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelAABB\include\BpBroadPhase.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelAABB\include\BpBroadPhaseUpdate.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelAABB\include\BpSimpleAABBManager.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevelAABB\src\BpBroadPhaseMBP.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelAABB\src\BpBroadPhaseMBPCommon.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelAABB\src\BpBroadPhaseSap.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelAABB\src\BpBroadPhaseSapAux.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelAABB\src\BpMBPTasks.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelAABB\src\BpSAPTasks.h">
+    </ClInclude>
+    <ClCompile Include="..\..\LowLevelAABB\src\BpBroadPhase.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelAABB\src\BpBroadPhaseMBP.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelAABB\src\BpBroadPhaseSap.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelAABB\src\BpBroadPhaseSapAux.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelAABB\src\BpMBPTasks.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelAABB\src\BpSAPTasks.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelAABB\src\BpSimpleAABBManager.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PhysX_3.4/Source/compiler/vc14win64/LowLevelCloth.vcxproj
+++ b/PhysX_3.4/Source/compiler/vc14win64/LowLevelCloth.vcxproj
@@ -1,338 +1,347 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{24546E40-3140-20F4-C5AC-E4001B9880B8}</ProjectGuid>
-		<RootNamespace>LowLevelCloth</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelCloth/debug\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)DEBUG</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../Common/src;./../../LowLevelCloth/include;./../../LowLevelCloth/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelCloth/checked\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)CHECKED</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../Common/src;./../../LowLevelCloth/include;./../../LowLevelCloth/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelCloth/profile\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)PROFILE</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../Common/src;./../../LowLevelCloth/include;./../../LowLevelCloth/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelCloth/release\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../Common/src;./../../LowLevelCloth/include;./../../LowLevelCloth/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<CustomBuild Include="..\..\LowLevelCloth\src\avx\SwSolveConstraints.cpp">
-			<Command Condition="'$(Configuration)|$(Platform)'=='debug|x64'">cl.exe /c /Zi /Ox /MT /arch:AVX /Fd"$(TargetDir)\$(TargetName).pdb" /Fo./x64/LowLevelCloth/debug/avx/SwSolveConstraints.obj ..\..\LowLevelCloth\src\avx\SwSolveConstraints.cpp</Command>
-			<Message Condition="'$(Configuration)|$(Platform)'=='debug|x64'">Building %(Identity)</Message>
-			<Outputs Condition="'$(Configuration)|$(Platform)'=='debug|x64'">./x64/LowLevelCloth/debug/avx/SwSolveConstraints.obj;</Outputs>
-			<Command Condition="'$(Configuration)|$(Platform)'=='checked|x64'">cl.exe /c /Zi /Ox /MT /arch:AVX /Fd"$(TargetDir)\$(TargetName).pdb" /Fo./x64/LowLevelCloth/checked/avx/SwSolveConstraints.obj ..\..\LowLevelCloth\src\avx\SwSolveConstraints.cpp</Command>
-			<Message Condition="'$(Configuration)|$(Platform)'=='checked|x64'">Building %(Identity)</Message>
-			<Outputs Condition="'$(Configuration)|$(Platform)'=='checked|x64'">./x64/LowLevelCloth/checked/avx/SwSolveConstraints.obj;</Outputs>
-			<Command Condition="'$(Configuration)|$(Platform)'=='profile|x64'">cl.exe /c /Zi /Ox /MT /arch:AVX /Fd"$(TargetDir)\$(TargetName).pdb" /Fo./x64/LowLevelCloth/profile/avx/SwSolveConstraints.obj ..\..\LowLevelCloth\src\avx\SwSolveConstraints.cpp</Command>
-			<Message Condition="'$(Configuration)|$(Platform)'=='profile|x64'">Building %(Identity)</Message>
-			<Outputs Condition="'$(Configuration)|$(Platform)'=='profile|x64'">./x64/LowLevelCloth/profile/avx/SwSolveConstraints.obj;</Outputs>
-			<Command Condition="'$(Configuration)|$(Platform)'=='release|x64'">cl.exe /c /Zi /Ox /MT /arch:AVX /Fd"$(TargetDir)\$(TargetName).pdb" /Fo./x64/LowLevelCloth/release/avx/SwSolveConstraints.obj ..\..\LowLevelCloth\src\avx\SwSolveConstraints.cpp</Command>
-			<Message Condition="'$(Configuration)|$(Platform)'=='release|x64'">Building %(Identity)</Message>
-			<Outputs Condition="'$(Configuration)|$(Platform)'=='release|x64'">./x64/LowLevelCloth/release/avx/SwSolveConstraints.obj;</Outputs>
-		</CustomBuild>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevelCloth\include\Cloth.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\include\Fabric.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\include\Factory.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\include\PhaseConfig.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\include\Range.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\include\Solver.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\include\Types.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevelCloth\src\Allocator.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\Array.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\BoundingBox.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\ClothBase.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\ClothImpl.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\IndexPair.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\IterationState.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\MovingAverage.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\PointInterpolator.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\Simd.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\Simd4f.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\Simd4i.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\SimdTypes.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\StackAllocator.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\SwCloth.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\SwClothData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\SwCollision.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\SwCollisionHelpers.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\SwFabric.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\SwFactory.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\SwInterCollision.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\SwSelfCollision.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\SwSolver.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\SwSolverKernel.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\TripletScheduler.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelCloth\src\Vec4T.h">
-		</ClInclude>
-		<ClCompile Include="..\..\LowLevelCloth\src\Allocator.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelCloth\src\Factory.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelCloth\src\PhaseConfig.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelCloth\src\SwCloth.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelCloth\src\SwClothData.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelCloth\src\SwCollision.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelCloth\src\SwFabric.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelCloth\src\SwFactory.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelCloth\src\SwInterCollision.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelCloth\src\SwSelfCollision.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelCloth\src\SwSolver.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelCloth\src\SwSolverKernel.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelCloth\src\TripletScheduler.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{24546E40-3140-20F4-C5AC-E4001B9880B8}</ProjectGuid>
+    <RootNamespace>LowLevelCloth</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelCloth/debug\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)DEBUG</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../Common/src;./../../LowLevelCloth/include;./../../LowLevelCloth/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelCloth/checked\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)CHECKED</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../Common/src;./../../LowLevelCloth/include;./../../LowLevelCloth/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelCloth/profile\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)PROFILE</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../Common/src;./../../LowLevelCloth/include;./../../LowLevelCloth/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelCloth/release\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../Common/src;./../../LowLevelCloth/include;./../../LowLevelCloth/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\LowLevelCloth\src\avx\SwSolveConstraints.cpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='debug|x64'">cl.exe /c /Zi /Ox /MT /arch:AVX /Fd"$(TargetDir)\$(TargetName).pdb" /Fo./x64/LowLevelCloth/debug/avx/SwSolveConstraints.obj ..\..\LowLevelCloth\src\avx\SwSolveConstraints.cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='debug|x64'">Building %(Identity)</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='debug|x64'">./x64/LowLevelCloth/debug/avx/SwSolveConstraints.obj;</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='checked|x64'">cl.exe /c /Zi /Ox /MT /arch:AVX /Fd"$(TargetDir)\$(TargetName).pdb" /Fo./x64/LowLevelCloth/checked/avx/SwSolveConstraints.obj ..\..\LowLevelCloth\src\avx\SwSolveConstraints.cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='checked|x64'">Building %(Identity)</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='checked|x64'">./x64/LowLevelCloth/checked/avx/SwSolveConstraints.obj;</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='profile|x64'">cl.exe /c /Zi /Ox /MT /arch:AVX /Fd"$(TargetDir)\$(TargetName).pdb" /Fo./x64/LowLevelCloth/profile/avx/SwSolveConstraints.obj ..\..\LowLevelCloth\src\avx\SwSolveConstraints.cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='profile|x64'">Building %(Identity)</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='profile|x64'">./x64/LowLevelCloth/profile/avx/SwSolveConstraints.obj;</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='release|x64'">cl.exe /c /Zi /Ox /MT /arch:AVX /Fd"$(TargetDir)\$(TargetName).pdb" /Fo./x64/LowLevelCloth/release/avx/SwSolveConstraints.obj ..\..\LowLevelCloth\src\avx\SwSolveConstraints.cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='release|x64'">Building %(Identity)</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='release|x64'">./x64/LowLevelCloth/release/avx/SwSolveConstraints.obj;</Outputs>
+    </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevelCloth\include\Cloth.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\include\Fabric.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\include\Factory.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\include\PhaseConfig.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\include\Range.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\include\Solver.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\include\Types.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevelCloth\src\Allocator.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\Array.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\BoundingBox.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\ClothBase.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\ClothImpl.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\IndexPair.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\IterationState.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\MovingAverage.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\PointInterpolator.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\Simd.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\Simd4f.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\Simd4i.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\SimdTypes.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\StackAllocator.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\SwCloth.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\SwClothData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\SwCollision.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\SwCollisionHelpers.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\SwFabric.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\SwFactory.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\SwInterCollision.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\SwSelfCollision.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\SwSolver.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\SwSolverKernel.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\TripletScheduler.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelCloth\src\Vec4T.h">
+    </ClInclude>
+    <ClCompile Include="..\..\LowLevelCloth\src\Allocator.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelCloth\src\Factory.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelCloth\src\PhaseConfig.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelCloth\src\SwCloth.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelCloth\src\SwClothData.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelCloth\src\SwCollision.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelCloth\src\SwFabric.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelCloth\src\SwFactory.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelCloth\src\SwInterCollision.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelCloth\src\SwSelfCollision.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelCloth\src\SwSolver.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelCloth\src\SwSolverKernel.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelCloth\src\TripletScheduler.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PhysX_3.4/Source/compiler/vc14win64/LowLevelDynamics.vcxproj
+++ b/PhysX_3.4/Source/compiler/vc14win64/LowLevelDynamics.vcxproj
@@ -1,366 +1,375 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{627F8A5F-9D82-F9B8-AA0E-05A2FA6C025E}</ProjectGuid>
-		<RootNamespace>LowLevelDynamics</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelDynamics/debug\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)DEBUG</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/src/contact;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelDynamics/include/windows;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelDynamics/checked\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)CHECKED</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/src/contact;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelDynamics/include/windows;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelDynamics/profile\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)PROFILE</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/src/contact;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelDynamics/include/windows;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelDynamics/release\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/src/contact;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelDynamics/include/windows;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyArticulation.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyArticulationContactPrep.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyArticulationContactPrepPF.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyArticulationHelper.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyArticulationScalar.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyArticulationSIMD.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyConstraintPartition.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyConstraintSetup.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyConstraintSetupBlock.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyContactPrep.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyContactPrep4.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyContactPrep4PF.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyContactPrepPF.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyDynamics.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyFrictionCorrelation.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyRigidBodyToSolverBody.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DySolverConstraints.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DySolverConstraintsBlock.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DySolverControl.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DySolverControlPF.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DySolverPFConstraints.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DySolverPFConstraintsBlock.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyThreadContext.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelDynamics\src\DyThresholdTable.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevelDynamics\include\DyArticulation.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\include\DyConstraint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\include\DyConstraintWriteBack.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\include\DyContext.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\include\DySleepingConfigulation.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\include\DyThresholdTable.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationContactPrep.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationFnsDebug.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationFnsScalar.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationFnsSimd.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationHelper.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationPImpl.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationReference.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationScalar.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationUtils.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyBodyCoreIntegrator.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyConstraintPartition.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyConstraintPrep.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyContactPrep.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyContactPrepShared.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyContactReduction.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyCorrelationBuffer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyDynamics.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyFrictionPatch.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyFrictionPatchStreamPair.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverBody.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverConstraint1D.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverConstraint1D4.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverConstraintDesc.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverConstraintExtShared.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverConstraintsShared.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverConstraintTypes.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverContact.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverContact4.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverContactPF.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverContactPF4.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverContext.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverControl.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverControlPF.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySolverExt.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DySpatial.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelDynamics\src\DyThreadContext.h">
-		</ClInclude>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{627F8A5F-9D82-F9B8-AA0E-05A2FA6C025E}</ProjectGuid>
+    <RootNamespace>LowLevelDynamics</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelDynamics/debug\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)DEBUG</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/src/contact;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelDynamics/include/windows;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelDynamics/checked\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)CHECKED</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/src/contact;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelDynamics/include/windows;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelDynamics/profile\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)PROFILE</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/src/contact;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelDynamics/include/windows;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelDynamics/release\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include;./../../../Include/GeomUtils;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/src;./../../PhysXProfile/include;./../../GeomUtils/src/contact;./../../LowLevel/API/include;./../../LowLevel/common/include;./../../LowLevel/common/include/pipeline;./../../LowLevel/common/include/pipeline/windows;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/software/include;./../../LowLevel/software/include/windows;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelDynamics/include/windows;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyArticulation.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyArticulationContactPrep.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyArticulationContactPrepPF.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyArticulationHelper.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyArticulationScalar.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyArticulationSIMD.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyConstraintPartition.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyConstraintSetup.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyConstraintSetupBlock.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyContactPrep.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyContactPrep4.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyContactPrep4PF.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyContactPrepPF.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyDynamics.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyFrictionCorrelation.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyRigidBodyToSolverBody.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DySolverConstraints.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DySolverConstraintsBlock.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DySolverControl.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DySolverControlPF.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DySolverPFConstraints.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DySolverPFConstraintsBlock.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyThreadContext.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelDynamics\src\DyThresholdTable.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevelDynamics\include\DyArticulation.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\include\DyConstraint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\include\DyConstraintWriteBack.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\include\DyContext.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\include\DySleepingConfigulation.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\include\DyThresholdTable.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationContactPrep.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationFnsDebug.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationFnsScalar.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationFnsSimd.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationHelper.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationPImpl.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationReference.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationScalar.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyArticulationUtils.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyBodyCoreIntegrator.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyConstraintPartition.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyConstraintPrep.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyContactPrep.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyContactPrepShared.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyContactReduction.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyCorrelationBuffer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyDynamics.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyFrictionPatch.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyFrictionPatchStreamPair.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverBody.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverConstraint1D.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverConstraint1D4.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverConstraintDesc.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverConstraintExtShared.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverConstraintsShared.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverConstraintTypes.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverContact.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverContact4.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverContactPF.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverContactPF4.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverContext.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverControl.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverControlPF.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySolverExt.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DySpatial.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelDynamics\src\DyThreadContext.h">
+    </ClInclude>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PhysX_3.4/Source/compiler/vc14win64/LowLevelParticles.vcxproj
+++ b/PhysX_3.4/Source/compiler/vc14win64/LowLevelParticles.vcxproj
@@ -1,334 +1,343 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{D18EB5F3-84D9-FD36-27C0-555ADB086FD3}</ProjectGuid>
-		<RootNamespace>LowLevelParticles</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelParticles/debug\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)DEBUG</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src;./../../LowLevelParticles/include;./../../LowLevelParticles/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../GeomUtils/src;./../../GeomUtils/src/convex;./../../GeomUtils/src/hf;./../../GeomUtils/src/mesh;./../../GeomUtils/headers;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelParticles/checked\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)CHECKED</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src;./../../LowLevelParticles/include;./../../LowLevelParticles/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../GeomUtils/src;./../../GeomUtils/src/convex;./../../GeomUtils/src/hf;./../../GeomUtils/src/mesh;./../../GeomUtils/headers;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelParticles/profile\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)PROFILE</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src;./../../LowLevelParticles/include;./../../LowLevelParticles/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../GeomUtils/src;./../../GeomUtils/src/convex;./../../GeomUtils/src/hf;./../../GeomUtils/src/mesh;./../../GeomUtils/headers;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/LowLevelParticles/release\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src;./../../LowLevelParticles/include;./../../LowLevelParticles/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../GeomUtils/src;./../../GeomUtils/src/convex;./../../GeomUtils/src/hf;./../../GeomUtils/src/mesh;./../../GeomUtils/headers;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevelParticles\include\PtBodyTransformVault.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\include\PtContext.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\include\PtGridCellVector.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\include\PtParticle.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\include\PtParticleContactManagerStream.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\include\PtParticleData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\include\PtParticleShape.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\include\PtParticleSystemCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\include\PtParticleSystemFlags.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\include\PtParticleSystemSim.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevelParticles\src\gpu\PtRigidBodyAccessGpu.h">
-		</ClInclude>
-		<ClCompile Include="..\..\LowLevelParticles\src\gpu\PtRigidBodyAccessGpu.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtBatcher.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtCollision.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtCollisionData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtCollisionHelper.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtCollisionMethods.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtCollisionParameters.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtConfig.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtConstants.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtContextCpu.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtDynamicHelper.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtDynamics.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtDynamicsKernels.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtDynamicsParameters.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtDynamicsTempBuffers.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtHeightFieldAabbTest.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtPacketSections.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtParticleCell.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtParticleOpcodeCache.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtParticleShapeCpu.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtParticleSystemSimCpu.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtSpatialHash.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtSpatialHashHelper.h">
-		</ClInclude>
-		<ClInclude Include="..\..\LowLevelParticles\src\PtTwoWayData.h">
-		</ClInclude>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtBatcher.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtBodyTransformVault.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtCollision.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtCollisionBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtCollisionCapsule.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtCollisionConvex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtCollisionMesh.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtCollisionPlane.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtCollisionSphere.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtContextCpu.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtDynamics.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtParticleData.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtParticleShapeCpu.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtParticleSystemSimCpu.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtSpatialHash.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\LowLevelParticles\src\PtSpatialLocalHash.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{D18EB5F3-84D9-FD36-27C0-555ADB086FD3}</ProjectGuid>
+    <RootNamespace>LowLevelParticles</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelParticles/debug\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)DEBUG</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src;./../../LowLevelParticles/include;./../../LowLevelParticles/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../GeomUtils/src;./../../GeomUtils/src/convex;./../../GeomUtils/src/hf;./../../GeomUtils/src/mesh;./../../GeomUtils/headers;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelParticles/checked\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)CHECKED</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src;./../../LowLevelParticles/include;./../../LowLevelParticles/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../GeomUtils/src;./../../GeomUtils/src/convex;./../../GeomUtils/src/hf;./../../GeomUtils/src/mesh;./../../GeomUtils/headers;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelParticles/profile\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)PROFILE</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src;./../../LowLevelParticles/include;./../../LowLevelParticles/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../GeomUtils/src;./../../GeomUtils/src/convex;./../../GeomUtils/src/hf;./../../GeomUtils/src/mesh;./../../GeomUtils/headers;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/LowLevelParticles/release\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../Common/src;./../../LowLevelParticles/include;./../../LowLevelParticles/src;./../../LowLevel/API/include;./../../LowLevel/common/include/utils;./../../GeomUtils/src;./../../GeomUtils/src/convex;./../../GeomUtils/src/hf;./../../GeomUtils/src/mesh;./../../GeomUtils/headers;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevelParticles\include\PtBodyTransformVault.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\include\PtContext.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\include\PtGridCellVector.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\include\PtParticle.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\include\PtParticleContactManagerStream.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\include\PtParticleData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\include\PtParticleShape.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\include\PtParticleSystemCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\include\PtParticleSystemFlags.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\include\PtParticleSystemSim.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevelParticles\src\gpu\PtRigidBodyAccessGpu.h">
+    </ClInclude>
+    <ClCompile Include="..\..\LowLevelParticles\src\gpu\PtRigidBodyAccessGpu.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtBatcher.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtCollision.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtCollisionData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtCollisionHelper.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtCollisionMethods.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtCollisionParameters.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtConfig.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtConstants.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtContextCpu.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtDynamicHelper.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtDynamics.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtDynamicsKernels.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtDynamicsParameters.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtDynamicsTempBuffers.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtHeightFieldAabbTest.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtPacketSections.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtParticleCell.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtParticleOpcodeCache.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtParticleShapeCpu.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtParticleSystemSimCpu.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtSpatialHash.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtSpatialHashHelper.h">
+    </ClInclude>
+    <ClInclude Include="..\..\LowLevelParticles\src\PtTwoWayData.h">
+    </ClInclude>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtBatcher.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtBodyTransformVault.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtCollision.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtCollisionBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtCollisionCapsule.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtCollisionConvex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtCollisionMesh.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtCollisionPlane.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtCollisionSphere.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtContextCpu.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtDynamics.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtParticleData.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtParticleShapeCpu.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtParticleSystemSimCpu.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtSpatialHash.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\LowLevelParticles\src\PtSpatialLocalHash.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PhysX_3.4/Source/compiler/vc14win64/PhysX.vcxproj
+++ b/PhysX_3.4/Source/compiler/vc14win64/PhysX.vcxproj
@@ -1,703 +1,715 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{FC0C1E74-2BE0-A8BC-4F0C-82D0F2EAB9A4}</ProjectGuid>
-		<RootNamespace>PhysX</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysX/debug\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3DEBUG_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../../Include/gpu;./../../PhysXGpu/include;./../../PhysX/src/device;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelParticles/include;./../../PhysX/src;./../../PhysX/src/buffering;./../../PhysX/src/particles;./../../PhysX/src/cloth;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../SceneQuery/include;./../../PhysXMetaData/core/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /DELAYLOAD:nvcuda.dll /DELAYLOAD:PxFoundationDEBUG_x64.dll /DELAYLOAD:PxPvdSDKDEBUG_x64.dll /DELAYLOAD:PhysX3CommonDEBUG_x64.dll /DEBUG</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3DEBUG_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysX/checked\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3CHECKED_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../Include/gpu;./../../PhysXGpu/include;./../../PhysX/src/device;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelParticles/include;./../../PhysX/src;./../../PhysX/src/buffering;./../../PhysX/src/particles;./../../PhysX/src/cloth;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../SceneQuery/include;./../../PhysXMetaData/core/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /DELAYLOAD:nvcuda.dll /DELAYLOAD:PxFoundationCHECKED_x64.dll /DELAYLOAD:PxPvdSDKCHECKED_x64.dll /DELAYLOAD:PhysX3CommonCHECKED_x64.dll</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3CHECKED_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysX/profile\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3PROFILE_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../Include/gpu;./../../PhysXGpu/include;./../../PhysX/src/device;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelParticles/include;./../../PhysX/src;./../../PhysX/src/buffering;./../../PhysX/src/particles;./../../PhysX/src/cloth;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../SceneQuery/include;./../../PhysXMetaData/core/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /DELAYLOAD:nvcuda.dll /DELAYLOAD:PxFoundationPROFILE_x64.dll /DELAYLOAD:PxPvdSDKPROFILE_x64.dll /DELAYLOAD:PhysX3CommonPROFILE_x64.dll /INCREMENTAL:NO /DEBUG</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3PROFILE_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysX/release\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../Include/gpu;./../../PhysXGpu/include;./../../PhysX/src/device;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelParticles/include;./../../PhysX/src;./../../PhysX/src/buffering;./../../PhysX/src/particles;./../../PhysX/src/cloth;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../SceneQuery/include;./../../PhysXMetaData/core/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /DELAYLOAD:nvcuda.dll /DELAYLOAD:PxFoundation_x64.dll /DELAYLOAD:PxPvdSDK_x64.dll /DELAYLOAD:PhysX3Common_x64.dll /INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ResourceCompile Include="..\resource_x64\PhysX3.rc">
-		</ResourceCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\PhysX\src\windows\NpWindowsDelayLoadHook.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysX\src\gpu\NpPhysicsGpu.h">
-		</ClInclude>
-		<ClCompile Include="..\..\PhysX\src\gpu\NpPhysicsGpu.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\gpu\PxGpu.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\gpu\PxParticleDeviceExclusive.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\gpu\PxParticleGpu.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\gpu\PxPhysXGpuModuleLoader.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\gpu\PxPhysXIndicatorDeviceExclusive.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\PhysX\src\device\windows\PhysXIndicatorWindows.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysX\src\device\nvPhysXtoDrv.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\device\PhysXIndicator.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysX\src\particles\NpParticleBaseTemplate.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\particles\NpParticleFluid.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\particles\NpParticleFluidReadData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\particles\NpParticleSystem.h">
-		</ClInclude>
-		<ClCompile Include="..\..\PhysX\src\particles\NpParticleFluid.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\particles\NpParticleSystem.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbActor.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbAggregate.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbArticulation.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbArticulationJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbBase.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbBody.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbCloth.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbConstraint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbDefs.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbNpDeps.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbParticleSystem.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbRigidObject.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbRigidStatic.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbScene.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbSceneBuffer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbScenePvdClient.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbShape.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\buffering\ScbType.h">
-		</ClInclude>
-		<ClCompile Include="..\..\PhysX\src\buffering\ScbActor.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\buffering\ScbAggregate.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\buffering\ScbBase.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\buffering\ScbCloth.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\buffering\ScbMetaData.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\buffering\ScbParticleSystem.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\buffering\ScbScene.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\buffering\ScbScenePvdClient.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\buffering\ScbShape.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysX\src\cloth\NpCloth.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\cloth\NpClothFabric.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\cloth\NpClothParticleData.h">
-		</ClInclude>
-		<ClCompile Include="..\..\PhysX\src\cloth\NpCloth.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\cloth\NpClothFabric.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\cloth\NpClothParticleData.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\ImmediateMode\src\NpImmediateMode.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysX\src\NpActor.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpActorTemplate.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpAggregate.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpArticulation.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpArticulationJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpArticulationLink.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpBatchQuery.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpCast.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpConnector.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpConstraint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpFactory.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpMaterial.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpMaterialManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpPhysics.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpPhysicsInsertionCallback.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpPtrTableStorageManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpPvdSceneQueryCollector.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpQueryShared.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpReadCheck.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpRigidActorTemplate.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpRigidActorTemplateInternal.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpRigidBodyTemplate.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpRigidDynamic.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpRigidStatic.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpScene.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpSceneQueries.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpShape.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpShapeManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpSpatialIndex.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpVolumeCache.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\NpWriteCheck.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\PvdMetaDataBindingData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\PvdMetaDataPvdBinding.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\PvdPhysicsClient.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysX\src\PvdTypeNames.h">
-		</ClInclude>
-		<ClCompile Include="..\..\PhysX\src\NpActor.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpAggregate.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpArticulation.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpArticulationJoint.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpArticulationLink.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpBatchQuery.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpConstraint.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpFactory.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpMaterial.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpMetaData.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpPhysics.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpPvdSceneQueryCollector.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpReadCheck.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpRigidDynamic.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpRigidStatic.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpScene.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpSceneQueries.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpSerializerAdapter.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpShape.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpShapeManager.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpSpatialIndex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpVolumeCache.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\NpWriteCheck.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\PvdMetaDataPvdBinding.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysX\src\PvdPhysicsClient.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\Include\gpu\PxGpu.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\gpu\PxParticleGpu.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\Include\particles\PxParticleBase.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\particles\PxParticleBaseFlag.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\particles\PxParticleCreationData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\particles\PxParticleFlag.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\particles\PxParticleFluid.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\particles\PxParticleFluidReadData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\particles\PxParticleReadData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\particles\PxParticleSystem.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\Include\pvd\PxPvdSceneClient.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\Include\cloth\PxCloth.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\cloth\PxClothCollisionData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\cloth\PxClothFabric.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\cloth\PxClothParticleData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\cloth\PxClothTypes.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\Include\common\windows\PxWindowsDelayLoadHook.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\Include\PxActor.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxAggregate.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxArticulation.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxArticulationJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxArticulationLink.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxBatchQuery.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxBatchQueryDesc.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxBroadPhase.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxClient.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxConstraint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxConstraintDesc.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxContact.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxContactModifyCallback.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxDeletionListener.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxFiltering.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxForceMode.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxImmediateMode.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxLockedData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxMaterial.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxPhysics.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxPhysicsAPI.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxPhysicsSerialization.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxPhysicsVersion.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxPhysXConfig.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxPruningStructure.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxQueryFiltering.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxQueryReport.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxRigidActor.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxRigidBody.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxRigidDynamic.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxRigidStatic.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxScene.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxSceneDesc.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxSceneLock.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxShape.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxSimulationEventCallback.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxSimulationStatistics.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxSpatialIndex.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxVisualizationParameter.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\PxVolumeCache.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PvdMetaDataDefineProperties.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PvdMetaDataExtensions.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PvdMetaDataPropertyVisitor.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PxAutoGeneratedMetaDataObjectNames.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PxAutoGeneratedMetaDataObjects.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PxMetaDataCompare.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PxMetaDataCppPrefix.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PxMetaDataObjects.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\RepXMetaDataPropertyVisitor.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\PhysXMetaData\core\src\PxAutoGeneratedMetaDataObjects.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXMetaData\core\src\PxMetaDataObjects.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PxPvdSDK.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PxFoundation.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./PhysXCommon.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./LowLevel.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./LowLevelAABB.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./LowLevelDynamics.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./LowLevelCloth.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./LowLevelParticles.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./SceneQuery.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./SimulationController.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PxTask.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{FC0C1E74-2BE0-A8BC-4F0C-82D0F2EAB9A4}</ProjectGuid>
+    <RootNamespace>PhysX</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysX/debug\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3DEBUG_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../../Include/gpu;./../../PhysXGpu/include;./../../PhysX/src/device;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelParticles/include;./../../PhysX/src;./../../PhysX/src/buffering;./../../PhysX/src/particles;./../../PhysX/src/cloth;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../SceneQuery/include;./../../PhysXMetaData/core/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /DELAYLOAD:nvcuda.dll /DELAYLOAD:PxFoundationDEBUG_x64.dll /DELAYLOAD:PxPvdSDKDEBUG_x64.dll /DELAYLOAD:PhysX3CommonDEBUG_x64.dll /DEBUG</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3DEBUG_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysX/checked\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3CHECKED_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../Include/gpu;./../../PhysXGpu/include;./../../PhysX/src/device;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelParticles/include;./../../PhysX/src;./../../PhysX/src/buffering;./../../PhysX/src/particles;./../../PhysX/src/cloth;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../SceneQuery/include;./../../PhysXMetaData/core/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /DELAYLOAD:nvcuda.dll /DELAYLOAD:PxFoundationCHECKED_x64.dll /DELAYLOAD:PxPvdSDKCHECKED_x64.dll /DELAYLOAD:PhysX3CommonCHECKED_x64.dll</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3CHECKED_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysX/profile\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3PROFILE_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../Include/gpu;./../../PhysXGpu/include;./../../PhysX/src/device;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelParticles/include;./../../PhysX/src;./../../PhysX/src/buffering;./../../PhysX/src/particles;./../../PhysX/src/cloth;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../SceneQuery/include;./../../PhysXMetaData/core/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /DELAYLOAD:nvcuda.dll /DELAYLOAD:PxFoundationPROFILE_x64.dll /DELAYLOAD:PxPvdSDKPROFILE_x64.dll /DELAYLOAD:PhysX3CommonPROFILE_x64.dll /INCREMENTAL:NO /DEBUG</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3PROFILE_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysX/release\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /wd4770 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../Include/gpu;./../../PhysXGpu/include;./../../PhysX/src/device;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/pipeline;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelDynamics/src;./../../LowLevelParticles/include;./../../PhysX/src;./../../PhysX/src/buffering;./../../PhysX/src/particles;./../../PhysX/src/cloth;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../SceneQuery/include;./../../PhysXMetaData/core/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /DELAYLOAD:nvcuda.dll /DELAYLOAD:PxFoundation_x64.dll /DELAYLOAD:PxPvdSDK_x64.dll /DELAYLOAD:PhysX3Common_x64.dll /INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\resource_x64\PhysX3.rc">
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\PhysX\src\windows\NpWindowsDelayLoadHook.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysX\src\gpu\NpPhysicsGpu.h">
+    </ClInclude>
+    <ClCompile Include="..\..\PhysX\src\gpu\NpPhysicsGpu.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\gpu\PxGpu.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\gpu\PxParticleDeviceExclusive.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\gpu\PxParticleGpu.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\gpu\PxPhysXGpuModuleLoader.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\gpu\PxPhysXIndicatorDeviceExclusive.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\PhysX\src\device\windows\PhysXIndicatorWindows.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysX\src\device\nvPhysXtoDrv.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\device\PhysXIndicator.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysX\src\particles\NpParticleBaseTemplate.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\particles\NpParticleFluid.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\particles\NpParticleFluidReadData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\particles\NpParticleSystem.h">
+    </ClInclude>
+    <ClCompile Include="..\..\PhysX\src\particles\NpParticleFluid.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\particles\NpParticleSystem.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbActor.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbAggregate.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbArticulation.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbArticulationJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbBase.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbBody.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbCloth.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbConstraint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbDefs.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbNpDeps.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbParticleSystem.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbRigidObject.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbRigidStatic.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbScene.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbSceneBuffer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbScenePvdClient.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbShape.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\buffering\ScbType.h">
+    </ClInclude>
+    <ClCompile Include="..\..\PhysX\src\buffering\ScbActor.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\buffering\ScbAggregate.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\buffering\ScbBase.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\buffering\ScbCloth.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\buffering\ScbMetaData.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\buffering\ScbParticleSystem.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\buffering\ScbScene.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\buffering\ScbScenePvdClient.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\buffering\ScbShape.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysX\src\cloth\NpCloth.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\cloth\NpClothFabric.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\cloth\NpClothParticleData.h">
+    </ClInclude>
+    <ClCompile Include="..\..\PhysX\src\cloth\NpCloth.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\cloth\NpClothFabric.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\cloth\NpClothParticleData.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\ImmediateMode\src\NpImmediateMode.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysX\src\NpActor.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpActorTemplate.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpAggregate.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpArticulation.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpArticulationJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpArticulationLink.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpBatchQuery.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpCast.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpConnector.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpConstraint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpFactory.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpMaterial.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpMaterialManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpPhysics.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpPhysicsInsertionCallback.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpPtrTableStorageManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpPvdSceneQueryCollector.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpQueryShared.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpReadCheck.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpRigidActorTemplate.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpRigidActorTemplateInternal.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpRigidBodyTemplate.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpRigidDynamic.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpRigidStatic.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpScene.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpSceneQueries.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpShape.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpShapeManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpSpatialIndex.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpVolumeCache.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\NpWriteCheck.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\PvdMetaDataBindingData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\PvdMetaDataPvdBinding.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\PvdPhysicsClient.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysX\src\PvdTypeNames.h">
+    </ClInclude>
+    <ClCompile Include="..\..\PhysX\src\NpActor.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpAggregate.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpArticulation.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpArticulationJoint.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpArticulationLink.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpBatchQuery.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpConstraint.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpFactory.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpMaterial.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpMetaData.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpPhysics.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpPvdSceneQueryCollector.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpReadCheck.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpRigidDynamic.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpRigidStatic.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpScene.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpSceneQueries.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpSerializerAdapter.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpShape.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpShapeManager.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpSpatialIndex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpVolumeCache.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\NpWriteCheck.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\PvdMetaDataPvdBinding.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysX\src\PvdPhysicsClient.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\Include\gpu\PxGpu.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\gpu\PxParticleGpu.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\Include\particles\PxParticleBase.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\particles\PxParticleBaseFlag.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\particles\PxParticleCreationData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\particles\PxParticleFlag.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\particles\PxParticleFluid.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\particles\PxParticleFluidReadData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\particles\PxParticleReadData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\particles\PxParticleSystem.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\Include\pvd\PxPvdSceneClient.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\Include\cloth\PxCloth.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\cloth\PxClothCollisionData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\cloth\PxClothFabric.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\cloth\PxClothParticleData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\cloth\PxClothTypes.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\Include\common\windows\PxWindowsDelayLoadHook.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\Include\PxActor.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxAggregate.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxArticulation.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxArticulationJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxArticulationLink.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxBatchQuery.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxBatchQueryDesc.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxBroadPhase.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxClient.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxConstraint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxConstraintDesc.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxContact.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxContactModifyCallback.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxDeletionListener.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxFiltering.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxForceMode.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxImmediateMode.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxLockedData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxMaterial.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxPhysics.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxPhysicsAPI.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxPhysicsSerialization.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxPhysicsVersion.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxPhysXConfig.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxPruningStructure.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxQueryFiltering.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxQueryReport.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxRigidActor.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxRigidBody.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxRigidDynamic.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxRigidStatic.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxScene.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxSceneDesc.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxSceneLock.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxShape.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxSimulationEventCallback.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxSimulationStatistics.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxSpatialIndex.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxVisualizationParameter.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\PxVolumeCache.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PvdMetaDataDefineProperties.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PvdMetaDataExtensions.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PvdMetaDataPropertyVisitor.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PxAutoGeneratedMetaDataObjectNames.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PxAutoGeneratedMetaDataObjects.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PxMetaDataCompare.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PxMetaDataCppPrefix.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PxMetaDataObjects.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\RepXMetaDataPropertyVisitor.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\PhysXMetaData\core\src\PxAutoGeneratedMetaDataObjects.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXMetaData\core\src\PxMetaDataObjects.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PxPvdSDK.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PxFoundation.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./PhysXCommon.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./LowLevel.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./LowLevelAABB.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./LowLevelDynamics.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./LowLevelCloth.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./LowLevelParticles.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./SceneQuery.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./SimulationController.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PxTask.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PhysX_3.4/Source/compiler/vc14win64/PhysXCharacterKinematic.vcxproj
+++ b/PhysX_3.4/Source/compiler/vc14win64/PhysXCharacterKinematic.vcxproj
@@ -1,321 +1,333 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{1E04F7A2-C8F8-3D62-46FE-8762D28CA9A4}</ProjectGuid>
-		<RootNamespace>PhysXCharacterKinematic</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXCharacterKinematic/debug\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3CharacterKinematicDEBUG_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/characterkinematic;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include;./../../GeomUtils/headers;./../../Common/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_PHYSX_CHARACTER_EXPORTS;PX_PHYSX_CORE_EXPORTS;PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /DEBUG</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3CharacterKinematicDEBUG_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXCharacterKinematic/checked\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3CharacterKinematicCHECKED_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/characterkinematic;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include;./../../GeomUtils/headers;./../../Common/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_PHYSX_CHARACTER_EXPORTS;PX_PHYSX_CORE_EXPORTS;PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3CharacterKinematicCHECKED_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXCharacterKinematic/profile\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3CharacterKinematicPROFILE_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/characterkinematic;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include;./../../GeomUtils/headers;./../../Common/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_PHYSX_CHARACTER_EXPORTS;PX_PHYSX_CORE_EXPORTS;PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /INCREMENTAL:NO /DEBUG</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3CharacterKinematicPROFILE_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXCharacterKinematic/release\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3CharacterKinematic_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/characterkinematic;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include;./../../GeomUtils/headers;./../../Common/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_PHYSX_CHARACTER_EXPORTS;PX_PHYSX_CORE_EXPORTS;PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3CharacterKinematic_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ResourceCompile Include="..\resource_x64\PhysX3CharacterKinematic.rc">
-		</ResourceCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\Include\characterkinematic\PxBoxController.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\characterkinematic\PxCapsuleController.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\characterkinematic\PxCharacter.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\characterkinematic\PxController.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\characterkinematic\PxControllerBehavior.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\characterkinematic\PxControllerManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\characterkinematic\PxControllerObstacles.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\characterkinematic\PxExtended.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysXCharacterKinematic\src\CctBoxController.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCharacterKinematic\src\CctCapsuleController.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCharacterKinematic\src\CctCharacterController.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCharacterKinematic\src\CctCharacterControllerManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCharacterKinematic\src\CctController.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCharacterKinematic\src\CctInternalStructs.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCharacterKinematic\src\CctObstacleContext.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCharacterKinematic\src\CctSweptBox.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCharacterKinematic\src\CctSweptCapsule.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCharacterKinematic\src\CctSweptVolume.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCharacterKinematic\src\CctUtils.h">
-		</ClInclude>
-		<ClCompile Include="..\..\PhysXCharacterKinematic\src\CctBoxController.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCharacterKinematic\src\CctCapsuleController.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCharacterKinematic\src\CctCharacterController.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCharacterKinematic\src\CctCharacterControllerCallbacks.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCharacterKinematic\src\CctCharacterControllerManager.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCharacterKinematic\src\CctController.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCharacterKinematic\src\CctObstacleContext.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCharacterKinematic\src\CctSweptBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCharacterKinematic\src\CctSweptCapsule.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCharacterKinematic\src\CctSweptVolume.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./PhysXExtensions.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PxFoundation.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./PhysXCommon.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{1E04F7A2-C8F8-3D62-46FE-8762D28CA9A4}</ProjectGuid>
+    <RootNamespace>PhysXCharacterKinematic</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXCharacterKinematic/debug\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3CharacterKinematicDEBUG_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/characterkinematic;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include;./../../GeomUtils/headers;./../../Common/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_PHYSX_CHARACTER_EXPORTS;PX_PHYSX_CORE_EXPORTS;PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /DEBUG</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3CharacterKinematicDEBUG_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXCharacterKinematic/checked\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3CharacterKinematicCHECKED_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/characterkinematic;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include;./../../GeomUtils/headers;./../../Common/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_PHYSX_CHARACTER_EXPORTS;PX_PHYSX_CORE_EXPORTS;PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3CharacterKinematicCHECKED_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXCharacterKinematic/profile\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3CharacterKinematicPROFILE_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/characterkinematic;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include;./../../GeomUtils/headers;./../../Common/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_PHYSX_CHARACTER_EXPORTS;PX_PHYSX_CORE_EXPORTS;PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /INCREMENTAL:NO /DEBUG</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3CharacterKinematicPROFILE_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXCharacterKinematic/release\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3CharacterKinematic_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/characterkinematic;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include;./../../GeomUtils/headers;./../../Common/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_PHYSX_CHARACTER_EXPORTS;PX_PHYSX_CORE_EXPORTS;PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3CharacterKinematic_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\resource_x64\PhysX3CharacterKinematic.rc">
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\Include\characterkinematic\PxBoxController.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\characterkinematic\PxCapsuleController.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\characterkinematic\PxCharacter.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\characterkinematic\PxController.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\characterkinematic\PxControllerBehavior.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\characterkinematic\PxControllerManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\characterkinematic\PxControllerObstacles.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\characterkinematic\PxExtended.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysXCharacterKinematic\src\CctBoxController.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCharacterKinematic\src\CctCapsuleController.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCharacterKinematic\src\CctCharacterController.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCharacterKinematic\src\CctCharacterControllerManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCharacterKinematic\src\CctController.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCharacterKinematic\src\CctInternalStructs.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCharacterKinematic\src\CctObstacleContext.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCharacterKinematic\src\CctSweptBox.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCharacterKinematic\src\CctSweptCapsule.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCharacterKinematic\src\CctSweptVolume.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCharacterKinematic\src\CctUtils.h">
+    </ClInclude>
+    <ClCompile Include="..\..\PhysXCharacterKinematic\src\CctBoxController.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCharacterKinematic\src\CctCapsuleController.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCharacterKinematic\src\CctCharacterController.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCharacterKinematic\src\CctCharacterControllerCallbacks.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCharacterKinematic\src\CctCharacterControllerManager.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCharacterKinematic\src\CctController.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCharacterKinematic\src\CctObstacleContext.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCharacterKinematic\src\CctSweptBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCharacterKinematic\src\CctSweptCapsule.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCharacterKinematic\src\CctSweptVolume.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./PhysXExtensions.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PxFoundation.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./PhysXCommon.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PhysX_3.4/Source/compiler/vc14win64/PhysXCommon.vcxproj
+++ b/PhysX_3.4/Source/compiler/vc14win64/PhysXCommon.vcxproj
@@ -1,977 +1,989 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{653CC2CD-99F5-48D8-0E9C-46FA10B26447}</ProjectGuid>
-		<RootNamespace>PhysXCommon</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXCommon/debug\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3CommonDEBUG_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/include;./../../PhysXProfile/src;./../../PhysXGpu/include;./../../../Include/geometry;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../../Include/GeomUtils;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_FOUNDATION_DLL=1;PX_PHYSX_COMMON_EXPORTS;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /DEBUG /DELAYLOAD:PxFoundationDEBUG_x64.dll</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3CommonDEBUG_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXCommon/checked\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3CommonCHECKED_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/include;./../../PhysXProfile/src;./../../PhysXGpu/include;./../../../Include/geometry;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../../Include/GeomUtils;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_FOUNDATION_DLL=1;PX_PHYSX_COMMON_EXPORTS;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /DELAYLOAD:PxFoundationCHECKED_x64.dll</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3CommonCHECKED_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXCommon/profile\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3CommonPROFILE_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/include;./../../PhysXProfile/src;./../../PhysXGpu/include;./../../../Include/geometry;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../../Include/GeomUtils;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_FOUNDATION_DLL=1;PX_PHYSX_COMMON_EXPORTS;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /INCREMENTAL:NO /DEBUG /DELAYLOAD:PxFoundationPROFILE_x64.dll</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3CommonPROFILE_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXCommon/release\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3Common_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/include;./../../PhysXProfile/src;./../../PhysXGpu/include;./../../../Include/geometry;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../../Include/GeomUtils;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_FOUNDATION_DLL=1;PX_PHYSX_COMMON_EXPORTS;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /INCREMENTAL:NO /DELAYLOAD:PxFoundation_x64.dll</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3Common_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ResourceCompile Include="..\resource_x64\PhysX3Common.rc">
-		</ResourceCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\Include\common\PxBase.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\common\PxCollection.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\common\PxCoreUtilityTypes.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\common\PxMetaData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\common\PxMetaDataFlags.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\common\PxPhysicsInsertionCallback.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\common\PxPhysXCommonConfig.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\common\PxRenderBuffer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\common\PxSerialFramework.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\common\PxSerializer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\common\PxStringTable.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\common\PxTolerancesScale.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\common\PxTypeInfo.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\Include\geometry\PxBoxGeometry.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxCapsuleGeometry.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxConvexMesh.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxConvexMeshGeometry.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxGeometry.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxGeometryHelpers.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxGeometryQuery.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxHeightField.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxHeightFieldDesc.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxHeightFieldFlag.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxHeightFieldGeometry.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxHeightFieldSample.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxMeshQuery.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxMeshScale.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxPlaneGeometry.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxSimpleTriangleMesh.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxSphereGeometry.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxTriangle.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxTriangleMesh.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\geometry\PxTriangleMeshGeometry.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\Common\src\windows\CmWindowsDelayLoadHook.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\Common\src\windows\CmWindowsModuleUpdateLoader.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\Common\src\CmBoxPruning.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\Common\src\CmCollection.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\Common\src\CmMathUtils.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\Common\src\CmPtrTable.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\Common\src\CmRadixSort.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\Common\src\CmRadixSortBuffered.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\Common\src\CmRenderOutput.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\Common\src\CmVisualization.cpp">
-		</ClCompile>
-		<ClInclude Include="..\..\Common\src\CmBitMap.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmBoxPruning.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmCollection.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmConeLimitHelper.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmFlushPool.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmIDPool.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmIO.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmMatrix34.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmPhysXCommon.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmPool.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmPreallocatingPool.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmPriorityQueue.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmPtrTable.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmQueue.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmRadixSort.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmRadixSortBuffered.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmRefCountable.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmRenderBuffer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmRenderOutput.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmScaling.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmSpatialVector.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmTask.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmTaskPool.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmTmpMem.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmTransformUtils.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmUtils.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\src\CmVisualization.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\Common\include\windows\CmWindowsLoadLibrary.h">
-		</ClInclude>
-		<ClInclude Include="..\..\Common\include\windows\CmWindowsModuleUpdateLoader.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\GeomUtils\headers\GuAxes.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\headers\GuBox.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\headers\GuDistanceSegmentBox.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\headers\GuDistanceSegmentSegment.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\headers\GuIntersectionBoxBox.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\headers\GuIntersectionTriangleBox.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\headers\GuRaycastTests.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\headers\GuSegment.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\headers\GuSIMDHelpers.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<None Include="..\..\..\Include\GeomUtils">
-		</None>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\GeomUtils\src\contact\GuContactMethodImpl.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\contact\GuContactPolygonPolygon.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\contact\GuFeatureCode.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\contact\GuLegacyTraceLineCallback.h">
-		</ClInclude>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactBoxBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactCapsuleBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactCapsuleCapsule.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactCapsuleConvex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactCapsuleMesh.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactConvexConvex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactConvexMesh.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactPlaneBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactPlaneCapsule.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactPlaneConvex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactPolygonPolygon.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactSphereBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactSphereCapsule.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactSphereMesh.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactSpherePlane.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuContactSphereSphere.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuFeatureCode.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuLegacyContactBoxHeightField.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuLegacyContactCapsuleHeightField.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuLegacyContactConvexHeightField.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\contact\GuLegacyContactSphereHeightField.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\GeomUtils\src\common\GuBarycentricCoordinates.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\common\GuBoxConversion.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\common\GuEdgeCache.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\common\GuEdgeListData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\common\GuSeparatingAxes.h">
-		</ClInclude>
-		<ClCompile Include="..\..\GeomUtils\src\common\GuBarycentricCoordinates.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\common\GuSeparatingAxes.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\GeomUtils\src\convex\GuBigConvexData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\convex\GuBigConvexData2.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\convex\GuConvexEdgeFlags.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\convex\GuConvexHelper.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\convex\GuConvexMesh.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\convex\GuConvexMeshData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\convex\GuConvexSupportTable.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\convex\GuConvexUtilsInternal.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\convex\GuCubeIndex.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\convex\GuHillClimbing.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\convex\GuShapeConvex.h">
-		</ClInclude>
-		<ClCompile Include="..\..\GeomUtils\src\convex\GuBigConvexData.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\convex\GuConvexHelper.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\convex\GuConvexMesh.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\convex\GuConvexSupportTable.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\convex\GuConvexUtilsInternal.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\convex\GuHillClimbing.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\convex\GuShapeConvex.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\GeomUtils\src\distance\GuDistancePointBox.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\distance\GuDistancePointSegment.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\distance\GuDistancePointTriangle.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\distance\GuDistancePointTriangleSIMD.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\distance\GuDistanceSegmentSegmentSIMD.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\distance\GuDistanceSegmentTriangle.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\distance\GuDistanceSegmentTriangleSIMD.h">
-		</ClInclude>
-		<ClCompile Include="..\..\GeomUtils\src\distance\GuDistancePointBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\distance\GuDistancePointTriangle.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\distance\GuDistanceSegmentBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\distance\GuDistanceSegmentSegment.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\distance\GuDistanceSegmentTriangle.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepBoxBox.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepBoxSphere.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepBoxTriangle_FeatureBased.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepBoxTriangle_SAT.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepCapsuleBox.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepCapsuleCapsule.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepCapsuleTriangle.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepSphereCapsule.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepSphereSphere.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepSphereTriangle.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepTriangleUtils.h">
-		</ClInclude>
-		<ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepBoxBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepBoxSphere.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepBoxTriangle_FeatureBased.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepBoxTriangle_SAT.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepCapsuleBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepCapsuleCapsule.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepCapsuleTriangle.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepSphereCapsule.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepSphereSphere.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepSphereTriangle.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepTriangleUtils.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuEPA.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuEPAFacet.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuGJK.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuGJKPenetration.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuGJKRaycast.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuGJKSimplex.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuGJKTest.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuGJKType.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuGJKUtil.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuVecBox.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuVecCapsule.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuVecConvex.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuVecConvexHull.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuVecConvexHullNoScale.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuVecPlane.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuVecShrunkBox.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuVecShrunkConvexHull.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuVecShrunkConvexHullNoScale.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuVecSphere.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\gjk\GuVecTriangle.h">
-		</ClInclude>
-		<ClCompile Include="..\..\GeomUtils\src\gjk\GuEPA.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\gjk\GuGJKSimplex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\gjk\GuGJKTest.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionCapsuleTriangle.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionEdgeEdge.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRay.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRayBox.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRayBoxSIMD.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRayCapsule.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRayPlane.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRaySphere.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRayTriangle.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionSphereBox.h">
-		</ClInclude>
-		<ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionBoxBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionCapsuleTriangle.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionEdgeEdge.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionRayBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionRayCapsule.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionRaySphere.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionSphereBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionTriangleBox.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV32.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV32Build.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4Build.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4Settings.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_AABBAABBSweepTest.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_BoxBoxOverlapTest.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_BoxOverlap_Internal.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_BoxSweep_Internal.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_BoxSweep_Params.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_CapsuleSweep_Internal.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Common.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Internal.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamNoOrder_OBBOBB.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamNoOrder_SegmentAABB.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamNoOrder_SegmentAABB_Inflated.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamNoOrder_SphereAABB.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamOrdered_OBBOBB.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamOrdered_SegmentAABB.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamOrdered_SegmentAABB_Inflated.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Slabs.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Slabs_KajiyaNoOrder.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Slabs_KajiyaOrdered.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Slabs_SwizzledNoOrder.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Slabs_SwizzledOrdered.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuBVConstants.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuMeshData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuMidphaseInterface.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuRTree.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuSweepConvexTri.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuSweepMesh.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuTriangle32.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuTriangleCache.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuTriangleMesh.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuTriangleMeshBV4.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuTriangleMeshRTree.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\mesh\GuTriangleVertexPointers.h">
-		</ClInclude>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuBV32.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuBV32Build.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4Build.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_AABBSweep.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_BoxOverlap.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_CapsuleSweep.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_CapsuleSweepAA.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_OBBSweep.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_Raycast.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_SphereOverlap.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_SphereSweep.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuMeshQuery.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuMidphaseBV4.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuMidphaseRTree.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuOverlapTestsMesh.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuRTree.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuRTreeQueries.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuSweepsMesh.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuTriangleMesh.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuTriangleMeshBV4.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\mesh\GuTriangleMeshRTree.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\GeomUtils\src\hf\GuEntityReport.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\hf\GuHeightField.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\hf\GuHeightFieldData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\hf\GuHeightFieldUtil.h">
-		</ClInclude>
-		<ClCompile Include="..\..\GeomUtils\src\hf\GuHeightField.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\hf\GuHeightFieldUtil.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\hf\GuOverlapTestsHF.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\hf\GuSweepsHF.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\GeomUtils\src\pcm\GuPCMContactConvexCommon.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\pcm\GuPCMContactGen.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\pcm\GuPCMContactGenUtil.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\pcm\GuPCMContactMeshCallback.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\pcm\GuPCMShapeConvex.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\pcm\GuPCMTriangleContactGen.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\pcm\GuPersistentContactManifold.h">
-		</ClInclude>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactBoxBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactBoxConvex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactCapsuleBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactCapsuleCapsule.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactCapsuleConvex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactCapsuleHeightField.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactCapsuleMesh.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactConvexCommon.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactConvexConvex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactConvexHeightField.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactConvexMesh.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactGenBoxConvex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactGenSphereCapsule.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactPlaneBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactPlaneCapsule.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactPlaneConvex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSphereBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSphereCapsule.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSphereConvex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSphereHeightField.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSphereMesh.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSpherePlane.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSphereSphere.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMShapeConvex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMTriangleContactGen.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\pcm\GuPersistentContactManifold.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\GeomUtils\src\ccd\GuCCDSweepConvexMesh.h">
-		</ClInclude>
-		<ClCompile Include="..\..\GeomUtils\src\ccd\GuCCDSweepConvexMesh.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\ccd\GuCCDSweepPrimitives.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\GeomUtils\src\GuBounds.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\GuCapsule.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\GuCenterExtents.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\GuGeometryUnion.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\GuInternal.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\GuMeshFactory.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\GuMTD.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\GuOverlapTests.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\GuSerialize.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\GuSphere.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\GuSweepMTD.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\GuSweepSharedTests.h">
-		</ClInclude>
-		<ClInclude Include="..\..\GeomUtils\src\GuSweepTests.h">
-		</ClInclude>
-		<ClCompile Include="..\..\GeomUtils\src\GuBounds.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuBox.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuCapsule.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuCCTSweepTests.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuGeometryQuery.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuGeometryUnion.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuInternal.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuMeshFactory.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuMetaData.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuMTD.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuOverlapTests.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuRaycastTests.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuSerialize.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuSweepMTD.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuSweepSharedTests.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\GeomUtils\src\GuSweepTests.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PxFoundation.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{653CC2CD-99F5-48D8-0E9C-46FA10B26447}</ProjectGuid>
+    <RootNamespace>PhysXCommon</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXCommon/debug\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3CommonDEBUG_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/include;./../../PhysXProfile/src;./../../PhysXGpu/include;./../../../Include/geometry;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../../Include/GeomUtils;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_FOUNDATION_DLL=1;PX_PHYSX_COMMON_EXPORTS;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /DEBUG /DELAYLOAD:PxFoundationDEBUG_x64.dll</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3CommonDEBUG_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXCommon/checked\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3CommonCHECKED_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/include;./../../PhysXProfile/src;./../../PhysXGpu/include;./../../../Include/geometry;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../../Include/GeomUtils;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_FOUNDATION_DLL=1;PX_PHYSX_COMMON_EXPORTS;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /DELAYLOAD:PxFoundationCHECKED_x64.dll</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3CommonCHECKED_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXCommon/profile\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3CommonPROFILE_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/include;./../../PhysXProfile/src;./../../PhysXGpu/include;./../../../Include/geometry;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../../Include/GeomUtils;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_FOUNDATION_DLL=1;PX_PHYSX_COMMON_EXPORTS;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /INCREMENTAL:NO /DEBUG /DELAYLOAD:PxFoundationPROFILE_x64.dll</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3CommonPROFILE_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXCommon/release\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3Common_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../../Externals/nvToolsExt/1/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../PhysXProfile/include;./../../PhysXProfile/src;./../../PhysXGpu/include;./../../../Include/geometry;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../../Include/GeomUtils;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_FOUNDATION_DLL=1;PX_PHYSX_COMMON_EXPORTS;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /INCREMENTAL:NO /DELAYLOAD:PxFoundation_x64.dll</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3Common_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\resource_x64\PhysX3Common.rc">
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\Include\common\PxBase.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\common\PxCollection.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\common\PxCoreUtilityTypes.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\common\PxMetaData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\common\PxMetaDataFlags.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\common\PxPhysicsInsertionCallback.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\common\PxPhysXCommonConfig.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\common\PxRenderBuffer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\common\PxSerialFramework.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\common\PxSerializer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\common\PxStringTable.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\common\PxTolerancesScale.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\common\PxTypeInfo.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\Include\geometry\PxBoxGeometry.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxCapsuleGeometry.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxConvexMesh.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxConvexMeshGeometry.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxGeometry.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxGeometryHelpers.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxGeometryQuery.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxHeightField.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxHeightFieldDesc.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxHeightFieldFlag.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxHeightFieldGeometry.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxHeightFieldSample.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxMeshQuery.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxMeshScale.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxPlaneGeometry.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxSimpleTriangleMesh.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxSphereGeometry.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxTriangle.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxTriangleMesh.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\geometry\PxTriangleMeshGeometry.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Common\src\windows\CmWindowsDelayLoadHook.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\Common\src\windows\CmWindowsModuleUpdateLoader.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Common\src\CmBoxPruning.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\Common\src\CmCollection.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\Common\src\CmMathUtils.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\Common\src\CmPtrTable.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\Common\src\CmRadixSort.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\Common\src\CmRadixSortBuffered.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\Common\src\CmRenderOutput.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\Common\src\CmVisualization.cpp">
+    </ClCompile>
+    <ClInclude Include="..\..\Common\src\CmBitMap.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmBoxPruning.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmCollection.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmConeLimitHelper.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmFlushPool.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmIDPool.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmIO.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmMatrix34.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmPhysXCommon.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmPool.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmPreallocatingPool.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmPriorityQueue.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmPtrTable.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmQueue.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmRadixSort.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmRadixSortBuffered.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmRefCountable.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmRenderBuffer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmRenderOutput.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmScaling.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmSpatialVector.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmTask.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmTaskPool.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmTmpMem.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmTransformUtils.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmUtils.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\src\CmVisualization.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\Common\include\windows\CmWindowsLoadLibrary.h">
+    </ClInclude>
+    <ClInclude Include="..\..\Common\include\windows\CmWindowsModuleUpdateLoader.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\GeomUtils\headers\GuAxes.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\headers\GuBox.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\headers\GuDistanceSegmentBox.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\headers\GuDistanceSegmentSegment.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\headers\GuIntersectionBoxBox.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\headers\GuIntersectionTriangleBox.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\headers\GuRaycastTests.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\headers\GuSegment.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\headers\GuSIMDHelpers.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\Include\GeomUtils">
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\GeomUtils\src\contact\GuContactMethodImpl.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\contact\GuContactPolygonPolygon.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\contact\GuFeatureCode.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\contact\GuLegacyTraceLineCallback.h">
+    </ClInclude>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactBoxBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactCapsuleBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactCapsuleCapsule.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactCapsuleConvex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactCapsuleMesh.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactConvexConvex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactConvexMesh.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactPlaneBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactPlaneCapsule.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactPlaneConvex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactPolygonPolygon.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactSphereBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactSphereCapsule.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactSphereMesh.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactSpherePlane.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuContactSphereSphere.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuFeatureCode.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuLegacyContactBoxHeightField.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuLegacyContactCapsuleHeightField.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuLegacyContactConvexHeightField.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\contact\GuLegacyContactSphereHeightField.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\GeomUtils\src\common\GuBarycentricCoordinates.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\common\GuBoxConversion.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\common\GuEdgeCache.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\common\GuEdgeListData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\common\GuSeparatingAxes.h">
+    </ClInclude>
+    <ClCompile Include="..\..\GeomUtils\src\common\GuBarycentricCoordinates.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\common\GuSeparatingAxes.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\GeomUtils\src\convex\GuBigConvexData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\convex\GuBigConvexData2.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\convex\GuConvexEdgeFlags.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\convex\GuConvexHelper.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\convex\GuConvexMesh.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\convex\GuConvexMeshData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\convex\GuConvexSupportTable.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\convex\GuConvexUtilsInternal.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\convex\GuCubeIndex.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\convex\GuHillClimbing.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\convex\GuShapeConvex.h">
+    </ClInclude>
+    <ClCompile Include="..\..\GeomUtils\src\convex\GuBigConvexData.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\convex\GuConvexHelper.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\convex\GuConvexMesh.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\convex\GuConvexSupportTable.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\convex\GuConvexUtilsInternal.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\convex\GuHillClimbing.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\convex\GuShapeConvex.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\GeomUtils\src\distance\GuDistancePointBox.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\distance\GuDistancePointSegment.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\distance\GuDistancePointTriangle.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\distance\GuDistancePointTriangleSIMD.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\distance\GuDistanceSegmentSegmentSIMD.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\distance\GuDistanceSegmentTriangle.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\distance\GuDistanceSegmentTriangleSIMD.h">
+    </ClInclude>
+    <ClCompile Include="..\..\GeomUtils\src\distance\GuDistancePointBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\distance\GuDistancePointTriangle.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\distance\GuDistanceSegmentBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\distance\GuDistanceSegmentSegment.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\distance\GuDistanceSegmentTriangle.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepBoxBox.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepBoxSphere.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepBoxTriangle_FeatureBased.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepBoxTriangle_SAT.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepCapsuleBox.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepCapsuleCapsule.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepCapsuleTriangle.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepSphereCapsule.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepSphereSphere.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepSphereTriangle.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\sweep\GuSweepTriangleUtils.h">
+    </ClInclude>
+    <ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepBoxBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepBoxSphere.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepBoxTriangle_FeatureBased.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepBoxTriangle_SAT.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepCapsuleBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepCapsuleCapsule.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepCapsuleTriangle.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepSphereCapsule.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepSphereSphere.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepSphereTriangle.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\sweep\GuSweepTriangleUtils.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuEPA.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuEPAFacet.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuGJK.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuGJKPenetration.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuGJKRaycast.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuGJKSimplex.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuGJKTest.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuGJKType.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuGJKUtil.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuVecBox.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuVecCapsule.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuVecConvex.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuVecConvexHull.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuVecConvexHullNoScale.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuVecPlane.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuVecShrunkBox.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuVecShrunkConvexHull.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuVecShrunkConvexHullNoScale.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuVecSphere.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\gjk\GuVecTriangle.h">
+    </ClInclude>
+    <ClCompile Include="..\..\GeomUtils\src\gjk\GuEPA.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\gjk\GuGJKSimplex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\gjk\GuGJKTest.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionCapsuleTriangle.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionEdgeEdge.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRay.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRayBox.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRayBoxSIMD.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRayCapsule.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRayPlane.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRaySphere.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionRayTriangle.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\intersection\GuIntersectionSphereBox.h">
+    </ClInclude>
+    <ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionBoxBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionCapsuleTriangle.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionEdgeEdge.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionRayBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionRayCapsule.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionRaySphere.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionSphereBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\intersection\GuIntersectionTriangleBox.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV32.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV32Build.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4Build.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4Settings.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_AABBAABBSweepTest.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_BoxBoxOverlapTest.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_BoxOverlap_Internal.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_BoxSweep_Internal.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_BoxSweep_Params.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_CapsuleSweep_Internal.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Common.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Internal.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamNoOrder_OBBOBB.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamNoOrder_SegmentAABB.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamNoOrder_SegmentAABB_Inflated.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamNoOrder_SphereAABB.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamOrdered_OBBOBB.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamOrdered_SegmentAABB.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_ProcessStreamOrdered_SegmentAABB_Inflated.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Slabs.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Slabs_KajiyaNoOrder.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Slabs_KajiyaOrdered.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Slabs_SwizzledNoOrder.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBV4_Slabs_SwizzledOrdered.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuBVConstants.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuMeshData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuMidphaseInterface.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuRTree.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuSweepConvexTri.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuSweepMesh.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuTriangle32.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuTriangleCache.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuTriangleMesh.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuTriangleMeshBV4.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuTriangleMeshRTree.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\mesh\GuTriangleVertexPointers.h">
+    </ClInclude>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuBV32.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuBV32Build.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4Build.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_AABBSweep.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_BoxOverlap.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_CapsuleSweep.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_CapsuleSweepAA.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_OBBSweep.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_Raycast.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_SphereOverlap.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuBV4_SphereSweep.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuMeshQuery.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuMidphaseBV4.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuMidphaseRTree.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuOverlapTestsMesh.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuRTree.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuRTreeQueries.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuSweepsMesh.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuTriangleMesh.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuTriangleMeshBV4.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\mesh\GuTriangleMeshRTree.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\GeomUtils\src\hf\GuEntityReport.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\hf\GuHeightField.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\hf\GuHeightFieldData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\hf\GuHeightFieldUtil.h">
+    </ClInclude>
+    <ClCompile Include="..\..\GeomUtils\src\hf\GuHeightField.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\hf\GuHeightFieldUtil.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\hf\GuOverlapTestsHF.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\hf\GuSweepsHF.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\GeomUtils\src\pcm\GuPCMContactConvexCommon.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\pcm\GuPCMContactGen.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\pcm\GuPCMContactGenUtil.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\pcm\GuPCMContactMeshCallback.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\pcm\GuPCMShapeConvex.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\pcm\GuPCMTriangleContactGen.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\pcm\GuPersistentContactManifold.h">
+    </ClInclude>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactBoxBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactBoxConvex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactCapsuleBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactCapsuleCapsule.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactCapsuleConvex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactCapsuleHeightField.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactCapsuleMesh.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactConvexCommon.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactConvexConvex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactConvexHeightField.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactConvexMesh.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactGenBoxConvex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactGenSphereCapsule.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactPlaneBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactPlaneCapsule.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactPlaneConvex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSphereBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSphereCapsule.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSphereConvex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSphereHeightField.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSphereMesh.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSpherePlane.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMContactSphereSphere.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMShapeConvex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPCMTriangleContactGen.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\pcm\GuPersistentContactManifold.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\GeomUtils\src\ccd\GuCCDSweepConvexMesh.h">
+    </ClInclude>
+    <ClCompile Include="..\..\GeomUtils\src\ccd\GuCCDSweepConvexMesh.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\ccd\GuCCDSweepPrimitives.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\GeomUtils\src\GuBounds.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\GuCapsule.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\GuCenterExtents.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\GuGeometryUnion.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\GuInternal.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\GuMeshFactory.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\GuMTD.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\GuOverlapTests.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\GuSerialize.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\GuSphere.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\GuSweepMTD.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\GuSweepSharedTests.h">
+    </ClInclude>
+    <ClInclude Include="..\..\GeomUtils\src\GuSweepTests.h">
+    </ClInclude>
+    <ClCompile Include="..\..\GeomUtils\src\GuBounds.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuBox.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuCapsule.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuCCTSweepTests.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuGeometryQuery.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuGeometryUnion.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuInternal.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuMeshFactory.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuMetaData.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuMTD.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuOverlapTests.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuRaycastTests.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuSerialize.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuSweepMTD.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuSweepSharedTests.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\GeomUtils\src\GuSweepTests.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PxFoundation.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PhysX_3.4/Source/compiler/vc14win64/PhysXCooking.vcxproj
+++ b/PhysX_3.4/Source/compiler/vc14win64/PhysXCooking.vcxproj
@@ -1,363 +1,375 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{C6474901-29F9-EF65-44E2-951696161E76}</ProjectGuid>
-		<RootNamespace>PhysXCooking</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXCooking/debug\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3CookingDEBUG_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/cloth;./../../../Include/cooking;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../PhysXExtensions/src;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_PHYSX_LOADER_EXPORTS;PX_PHYSX_COOKING_EXPORTS;PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_COOKING;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /DEBUG /DELAYLOAD:PxFoundationDEBUG_x64.dll /DELAYLOAD:PhysX3CommonDEBUG_x64.dll</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3CookingDEBUG_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXCooking/checked\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3CookingCHECKED_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/cloth;./../../../Include/cooking;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../PhysXExtensions/src;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_PHYSX_LOADER_EXPORTS;PX_PHYSX_COOKING_EXPORTS;PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_COOKING;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /DELAYLOAD:PxFoundationCHECKED_x64.dll /DELAYLOAD:PhysX3CommonCHECKED_x64.dll</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3CookingCHECKED_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXCooking/profile\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3CookingPROFILE_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/cloth;./../../../Include/cooking;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../PhysXExtensions/src;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_PHYSX_LOADER_EXPORTS;PX_PHYSX_COOKING_EXPORTS;PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_COOKING;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /INCREMENTAL:NO /DEBUG /DELAYLOAD:PxFoundationPROFILE_x64.dll /DELAYLOAD:PhysX3CommonPROFILE_x64.dll</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3CookingPROFILE_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXCooking/release\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PhysX3Cooking_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/cloth;./../../../Include/cooking;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../PhysXExtensions/src;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_PHYSX_LOADER_EXPORTS;PX_PHYSX_COOKING_EXPORTS;PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_COOKING;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/MAP /MACHINE:x64 /INCREMENTAL:NO /DELAYLOAD:PxFoundation_x64.dll /DELAYLOAD:PhysX3Common_x64.dll</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3Cooking_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ResourceCompile Include="..\resource_x64\PhysX3Cooking.rc">
-		</ResourceCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\PhysXCooking\src\windows\WindowsCookingDelayLoadHook.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\PhysXCooking\src\mesh\GrbTriangleMeshCooking.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\mesh\HeightFieldCooking.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\mesh\RTreeCooking.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\mesh\TriangleMeshBuilder.cpp">
-		</ClCompile>
-		<ClInclude Include="..\..\PhysXCooking\src\mesh\GrbTriangleMeshCooking.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\mesh\HeightFieldCooking.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\mesh\QuickSelect.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\mesh\RTreeCooking.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\mesh\TriangleMeshBuilder.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\PhysXCooking\src\convex\BigConvexDataBuilder.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\convex\ConvexHullBuilder.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\convex\ConvexHullLib.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\convex\ConvexHullUtils.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\convex\ConvexMeshBuilder.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\convex\ConvexPolygonsBuilder.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\convex\InflationConvexHullLib.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\convex\QuickHullConvexHullLib.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\convex\VolumeIntegration.cpp">
-		</ClCompile>
-		<ClInclude Include="..\..\PhysXCooking\src\convex\BigConvexDataBuilder.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\convex\ConvexHullBuilder.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\convex\ConvexHullLib.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\convex\ConvexHullUtils.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\convex\ConvexMeshBuilder.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\convex\ConvexPolygonsBuilder.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\convex\InflationConvexHullLib.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\convex\QuickHullConvexHullLib.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\convex\VolumeIntegration.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\PhysXCooking\src\Adjacencies.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\Cooking.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\CookingUtils.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\EdgeList.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\MeshCleaner.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXCooking\src\Quantizer.cpp">
-		</ClCompile>
-		<ClInclude Include="..\..\PhysXCooking\src\Adjacencies.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\Cooking.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\CookingUtils.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\EdgeList.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\MeshCleaner.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXCooking\src\Quantizer.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\Include\cooking\PxBVH33MidphaseDesc.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\cooking\PxBVH34MidphaseDesc.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\cooking\Pxc.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\cooking\PxConvexMeshDesc.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\cooking\PxCooking.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\cooking\PxMidphaseDesc.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\cooking\PxTriangleMeshDesc.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PxFoundation.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./PhysXCommon.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./PhysXExtensions.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C6474901-29F9-EF65-44E2-951696161E76}</ProjectGuid>
+    <RootNamespace>PhysXCooking</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXCooking/debug\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3CookingDEBUG_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/cloth;./../../../Include/cooking;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../PhysXExtensions/src;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_PHYSX_LOADER_EXPORTS;PX_PHYSX_COOKING_EXPORTS;PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_COOKING;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /DEBUG /DELAYLOAD:PxFoundationDEBUG_x64.dll /DELAYLOAD:PhysX3CommonDEBUG_x64.dll</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3CookingDEBUG_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXCooking/checked\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3CookingCHECKED_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/cloth;./../../../Include/cooking;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../PhysXExtensions/src;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_PHYSX_LOADER_EXPORTS;PX_PHYSX_COOKING_EXPORTS;PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_COOKING;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=CHECKED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /DELAYLOAD:PxFoundationCHECKED_x64.dll /DELAYLOAD:PhysX3CommonCHECKED_x64.dll</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3CookingCHECKED_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXCooking/profile\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3CookingPROFILE_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/cloth;./../../../Include/cooking;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../PhysXExtensions/src;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_PHYSX_LOADER_EXPORTS;PX_PHYSX_COOKING_EXPORTS;PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_COOKING;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;PX_PHYSX_DLL_NAME_POSTFIX=PROFILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /INCREMENTAL:NO /DEBUG /DELAYLOAD:PxFoundationPROFILE_x64.dll /DELAYLOAD:PhysX3CommonPROFILE_x64.dll</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3CookingPROFILE_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXCooking/release\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PhysX3Cooking_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/cloth;./../../../Include/cooking;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../PhysXCooking/src;./../../PhysXCooking/src/mesh;./../../PhysXCooking/src/convex;./../../PhysXExtensions/src;./../../PhysXGpu/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_PHYSX_LOADER_EXPORTS;PX_PHYSX_COOKING_EXPORTS;PX_PHYSX_CORE_EXPORTS;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_COOKING;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/MAP /MACHINE:x64 /INCREMENTAL:NO /DELAYLOAD:PxFoundation_x64.dll /DELAYLOAD:PhysX3Common_x64.dll</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3Cooking_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../Lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\resource_x64\PhysX3Cooking.rc">
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\PhysXCooking\src\windows\WindowsCookingDelayLoadHook.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\PhysXCooking\src\mesh\GrbTriangleMeshCooking.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\mesh\HeightFieldCooking.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\mesh\RTreeCooking.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\mesh\TriangleMeshBuilder.cpp">
+    </ClCompile>
+    <ClInclude Include="..\..\PhysXCooking\src\mesh\GrbTriangleMeshCooking.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\mesh\HeightFieldCooking.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\mesh\QuickSelect.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\mesh\RTreeCooking.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\mesh\TriangleMeshBuilder.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\PhysXCooking\src\convex\BigConvexDataBuilder.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\convex\ConvexHullBuilder.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\convex\ConvexHullLib.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\convex\ConvexHullUtils.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\convex\ConvexMeshBuilder.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\convex\ConvexPolygonsBuilder.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\convex\InflationConvexHullLib.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\convex\QuickHullConvexHullLib.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\convex\VolumeIntegration.cpp">
+    </ClCompile>
+    <ClInclude Include="..\..\PhysXCooking\src\convex\BigConvexDataBuilder.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\convex\ConvexHullBuilder.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\convex\ConvexHullLib.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\convex\ConvexHullUtils.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\convex\ConvexMeshBuilder.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\convex\ConvexPolygonsBuilder.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\convex\InflationConvexHullLib.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\convex\QuickHullConvexHullLib.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\convex\VolumeIntegration.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\PhysXCooking\src\Adjacencies.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\Cooking.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\CookingUtils.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\EdgeList.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\MeshCleaner.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXCooking\src\Quantizer.cpp">
+    </ClCompile>
+    <ClInclude Include="..\..\PhysXCooking\src\Adjacencies.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\Cooking.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\CookingUtils.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\EdgeList.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\MeshCleaner.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXCooking\src\Quantizer.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\Include\cooking\PxBVH33MidphaseDesc.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\cooking\PxBVH34MidphaseDesc.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\cooking\Pxc.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\cooking\PxConvexMeshDesc.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\cooking\PxCooking.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\cooking\PxMidphaseDesc.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\cooking\PxTriangleMeshDesc.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PxFoundation.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./PhysXCommon.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./PhysXExtensions.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PhysX_3.4/Source/compiler/vc14win64/PhysXExtensions.vcxproj
+++ b/PhysX_3.4/Source/compiler/vc14win64/PhysXExtensions.vcxproj
@@ -1,559 +1,568 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{2C6C10D1-F63D-B7F0-8390-AFC3DC10EC90}</ProjectGuid>
-		<RootNamespace>PhysXExtensions</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXExtensions/debug\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>PhysX3ExtensionsDEBUG</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/cooking;./../../../Include/extensions;./../../../Include/vehicle;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../PhysXMetaData/core/include;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXExtensions/src/serialization/Binary;./../../PhysXExtensions/src/serialization/File;./../../PvdSDK/src;./../../PhysX/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_BUILD_NUMBER=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3ExtensionsDEBUG.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXExtensions/checked\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>PhysX3ExtensionsCHECKED</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/cooking;./../../../Include/extensions;./../../../Include/vehicle;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../PhysXMetaData/core/include;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXExtensions/src/serialization/Binary;./../../PhysXExtensions/src/serialization/File;./../../PvdSDK/src;./../../PhysX/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_BUILD_NUMBER=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3ExtensionsCHECKED.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXExtensions/profile\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>PhysX3ExtensionsPROFILE</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/cooking;./../../../Include/extensions;./../../../Include/vehicle;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../PhysXMetaData/core/include;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXExtensions/src/serialization/Binary;./../../PhysXExtensions/src/serialization/File;./../../PvdSDK/src;./../../PhysX/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_BUILD_NUMBER=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3ExtensionsPROFILE.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXExtensions/release\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>PhysX3Extensions</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/cooking;./../../../Include/extensions;./../../../Include/vehicle;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../PhysXMetaData/core/include;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXExtensions/src/serialization/Binary;./../../PhysXExtensions/src/serialization/File;./../../PvdSDK/src;./../../PhysX/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_BUILD_NUMBER=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3Extensions.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\Include\extensions\PxBinaryConverter.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxBroadPhaseExt.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxClothFabricCooker.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxClothMeshDesc.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxClothMeshQuadifier.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxClothTetherCooker.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxCollectionExt.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxConstraintExt.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxConvexMeshExt.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxD6Joint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxDefaultAllocator.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxDefaultCpuDispatcher.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxDefaultErrorCallback.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxDefaultSimulationFilterShader.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxDefaultStreams.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxDistanceJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxExtensionsAPI.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxFixedJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxJointLimit.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxMassProperties.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxParticleExt.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxPrismaticJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxRaycastCCD.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxRepXSerializer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxRepXSimpleType.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxRevoluteJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxRigidActorExt.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxRigidBodyExt.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxSceneQueryExt.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxSerialization.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxShapeExt.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxSimpleFactory.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxSmoothNormals.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxSphericalJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxStringTableExt.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\extensions\PxTriangleMeshExt.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtConstraintHelper.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtCpuWorkerThread.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtD6Joint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtDefaultCpuDispatcher.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtDistanceJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtFixedJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtInertiaTensor.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtJointMetaDataExtensions.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtPlatform.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtPrismaticJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtPvd.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtRevoluteJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtSerialization.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtSharedQueueEntryPool.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtSphericalJoint.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\ExtTaskQueueHelper.h">
-		</ClInclude>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtBroadPhase.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtClothFabricCooker.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtClothGeodesicTetherCooker.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtClothMeshQuadifier.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtClothSimpleTetherCooker.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtCollection.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtConvexMeshExt.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtCpuWorkerThread.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtD6Joint.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtD6JointSolverPrep.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtDefaultCpuDispatcher.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtDefaultErrorCallback.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtDefaultSimulationFilterShader.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtDefaultStreams.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtDistanceJoint.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtDistanceJointSolverPrep.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtExtensions.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtFixedJoint.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtFixedJointSolverPrep.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtJoint.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtMetaData.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtParticleExt.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtPrismaticJoint.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtPrismaticJointSolverPrep.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtPvd.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtPxStringTable.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtRaycastCCD.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtRevoluteJoint.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtRevoluteJointSolverPrep.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtRigidBodyExt.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtSceneQueryExt.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtSimpleFactory.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtSmoothNormals.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtSphericalJoint.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtSphericalJointSolverPrep.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\ExtTriangleMeshExt.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Align.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Common.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_MetaData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Output.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Union.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnSerializationContext.h">
-		</ClInclude>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnBinaryDeserialization.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnBinarySerialization.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Align.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Convert.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Error.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_MetaData.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Output.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Union.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnSerializationContext.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnJointRepXSerializer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnPxStreamOperators.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepX1_0Defaults.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepX3_1Defaults.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepX3_2Defaults.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepXCollection.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepXCoreSerializer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepXSerializerImpl.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepXUpgrader.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnSimpleXmlWriter.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlDeserializer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlImpl.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlMemoryAllocator.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlMemoryPool.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlMemoryPoolStreams.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlReader.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlSerializer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlSimpleXmlWriter.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlStringToType.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlVisitorReader.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlVisitorWriter.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlWriter.h">
-		</ClInclude>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Xml\SnJointRepXSerializer.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepXCoreSerializer.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepXUpgrader.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlSerialization.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\File\SnFile.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\SnSerializationRegistry.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXExtensions\src\serialization\SnSerialUtils.h">
-		</ClInclude>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\SnSerialization.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\SnSerializationRegistry.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXExtensions\src\serialization\SnSerialUtils.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PvdMetaDataDefineProperties.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PvdMetaDataExtensions.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PvdMetaDataPropertyVisitor.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PxAutoGeneratedMetaDataObjectNames.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PxAutoGeneratedMetaDataObjects.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PxMetaDataCompare.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PxMetaDataCppPrefix.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\PxMetaDataObjects.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\core\include\RepXMetaDataPropertyVisitor.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysXMetaData\extensions\include\PxExtensionAutoGeneratedMetaDataObjectNames.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\extensions\include\PxExtensionAutoGeneratedMetaDataObjects.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXMetaData\extensions\include\PxExtensionMetaDataObjects.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\PhysXMetaData\extensions\src\PxExtensionAutoGeneratedMetaDataObjects.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PsFastXml.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{2C6C10D1-F63D-B7F0-8390-AFC3DC10EC90}</ProjectGuid>
+    <RootNamespace>PhysXExtensions</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXExtensions/debug\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>PhysX3ExtensionsDEBUG</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/cooking;./../../../Include/extensions;./../../../Include/vehicle;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../PhysXMetaData/core/include;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXExtensions/src/serialization/Binary;./../../PhysXExtensions/src/serialization/File;./../../PvdSDK/src;./../../PhysX/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_BUILD_NUMBER=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3ExtensionsDEBUG.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXExtensions/checked\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>PhysX3ExtensionsCHECKED</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/cooking;./../../../Include/extensions;./../../../Include/vehicle;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../PhysXMetaData/core/include;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXExtensions/src/serialization/Binary;./../../PhysXExtensions/src/serialization/File;./../../PvdSDK/src;./../../PhysX/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_BUILD_NUMBER=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3ExtensionsCHECKED.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXExtensions/profile\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>PhysX3ExtensionsPROFILE</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/cooking;./../../../Include/extensions;./../../../Include/vehicle;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../PhysXMetaData/core/include;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXExtensions/src/serialization/Binary;./../../PhysXExtensions/src/serialization/File;./../../PvdSDK/src;./../../PhysX/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_BUILD_NUMBER=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3ExtensionsPROFILE.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXExtensions/release\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>PhysX3Extensions</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/cooking;./../../../Include/extensions;./../../../Include/vehicle;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../PhysXMetaData/core/include;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXExtensions/src/serialization/Binary;./../../PhysXExtensions/src/serialization/File;./../../PvdSDK/src;./../../PhysX/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_BUILD_NUMBER=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3Extensions.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\Include\extensions\PxBinaryConverter.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxBroadPhaseExt.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxClothFabricCooker.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxClothMeshDesc.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxClothMeshQuadifier.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxClothTetherCooker.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxCollectionExt.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxConstraintExt.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxConvexMeshExt.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxD6Joint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxDefaultAllocator.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxDefaultCpuDispatcher.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxDefaultErrorCallback.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxDefaultSimulationFilterShader.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxDefaultStreams.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxDistanceJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxExtensionsAPI.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxFixedJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxJointLimit.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxMassProperties.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxParticleExt.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxPrismaticJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxRaycastCCD.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxRepXSerializer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxRepXSimpleType.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxRevoluteJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxRigidActorExt.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxRigidBodyExt.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxSceneQueryExt.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxSerialization.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxShapeExt.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxSimpleFactory.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxSmoothNormals.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxSphericalJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxStringTableExt.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\extensions\PxTriangleMeshExt.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtConstraintHelper.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtCpuWorkerThread.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtD6Joint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtDefaultCpuDispatcher.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtDistanceJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtFixedJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtInertiaTensor.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtJointMetaDataExtensions.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtPlatform.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtPrismaticJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtPvd.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtRevoluteJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtSerialization.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtSharedQueueEntryPool.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtSphericalJoint.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\ExtTaskQueueHelper.h">
+    </ClInclude>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtBroadPhase.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtClothFabricCooker.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtClothGeodesicTetherCooker.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtClothMeshQuadifier.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtClothSimpleTetherCooker.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtCollection.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtConvexMeshExt.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtCpuWorkerThread.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtD6Joint.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtD6JointSolverPrep.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtDefaultCpuDispatcher.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtDefaultErrorCallback.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtDefaultSimulationFilterShader.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtDefaultStreams.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtDistanceJoint.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtDistanceJointSolverPrep.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtExtensions.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtFixedJoint.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtFixedJointSolverPrep.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtJoint.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtMetaData.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtParticleExt.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtPrismaticJoint.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtPrismaticJointSolverPrep.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtPvd.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtPxStringTable.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtRaycastCCD.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtRevoluteJoint.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtRevoluteJointSolverPrep.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtRigidBodyExt.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtSceneQueryExt.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtSimpleFactory.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtSmoothNormals.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtSphericalJoint.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtSphericalJointSolverPrep.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\ExtTriangleMeshExt.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Align.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Common.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_MetaData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Output.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Union.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Binary\SnSerializationContext.h">
+    </ClInclude>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnBinaryDeserialization.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnBinarySerialization.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Align.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Convert.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Error.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_MetaData.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Output.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnConvX_Union.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Binary\SnSerializationContext.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnJointRepXSerializer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnPxStreamOperators.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepX1_0Defaults.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepX3_1Defaults.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepX3_2Defaults.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepXCollection.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepXCoreSerializer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepXSerializerImpl.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepXUpgrader.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnSimpleXmlWriter.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlDeserializer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlImpl.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlMemoryAllocator.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlMemoryPool.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlMemoryPoolStreams.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlReader.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlSerializer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlSimpleXmlWriter.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlStringToType.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlVisitorReader.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlVisitorWriter.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlWriter.h">
+    </ClInclude>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Xml\SnJointRepXSerializer.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepXCoreSerializer.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Xml\SnRepXUpgrader.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\Xml\SnXmlSerialization.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\File\SnFile.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\SnSerializationRegistry.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXExtensions\src\serialization\SnSerialUtils.h">
+    </ClInclude>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\SnSerialization.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\SnSerializationRegistry.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXExtensions\src\serialization\SnSerialUtils.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PvdMetaDataDefineProperties.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PvdMetaDataExtensions.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PvdMetaDataPropertyVisitor.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PxAutoGeneratedMetaDataObjectNames.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PxAutoGeneratedMetaDataObjects.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PxMetaDataCompare.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PxMetaDataCppPrefix.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\PxMetaDataObjects.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\core\include\RepXMetaDataPropertyVisitor.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysXMetaData\extensions\include\PxExtensionAutoGeneratedMetaDataObjectNames.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\extensions\include\PxExtensionAutoGeneratedMetaDataObjects.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXMetaData\extensions\include\PxExtensionMetaDataObjects.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\PhysXMetaData\extensions\src\PxExtensionAutoGeneratedMetaDataObjects.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./../../../../PxShared/src/compiler/vc14win64/PsFastXml.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PhysX_3.4/Source/compiler/vc14win64/PhysXVehicle.vcxproj
+++ b/PhysX_3.4/Source/compiler/vc14win64/PhysXVehicle.vcxproj
@@ -1,318 +1,327 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{BC4778D3-142F-31D0-46EC-77203F28C874}</ProjectGuid>
-		<RootNamespace>PhysXVehicle</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXVehicle/debug\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>PhysX3VehicleDEBUG</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/vehicle;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include/cloth;./../../../Include;./../../../Include/pvd;./../../../Include/physxprofilesdk;./../../Common/src;./../../PhysXVehicle/src;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXMetaData/core/include;./../../PhysXVehicle/src/PhysXMetaData/include;./../../PvdSDK/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3VehicleDEBUG.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXVehicle/checked\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>PhysX3VehicleCHECKED</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/vehicle;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include/cloth;./../../../Include;./../../../Include/pvd;./../../../Include/physxprofilesdk;./../../Common/src;./../../PhysXVehicle/src;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXMetaData/core/include;./../../PhysXVehicle/src/PhysXMetaData/include;./../../PvdSDK/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3VehicleCHECKED.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXVehicle/profile\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>PhysX3VehiclePROFILE</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/vehicle;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include/cloth;./../../../Include;./../../../Include/pvd;./../../../Include/physxprofilesdk;./../../Common/src;./../../PhysXVehicle/src;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXMetaData/core/include;./../../PhysXVehicle/src/PhysXMetaData/include;./../../PvdSDK/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3VehiclePROFILE.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/PhysXVehicle/release\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>PhysX3Vehicle</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/vehicle;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include/cloth;./../../../Include;./../../../Include/pvd;./../../../Include/physxprofilesdk;./../../Common/src;./../../PhysXVehicle/src;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXMetaData/core/include;./../../PhysXVehicle/src/PhysXMetaData/include;./../../PvdSDK/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PhysX3Vehicle.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleComponents.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleDrive.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleDrive4W.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleDriveNW.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleDriveTank.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleNoDrive.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleSDK.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleShaders.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleTireFriction.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleUpdate.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleUtil.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleUtilControl.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleUtilSetup.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleUtilTelemetry.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\Include\vehicle\PxVehicleWheels.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysXVehicle\src\PxVehicleDefaults.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXVehicle\src\PxVehicleLinearMath.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXVehicle\src\PxVehicleSerialization.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXVehicle\src\PxVehicleSuspLimitConstraintShader.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXVehicle\src\PxVehicleSuspWheelTire4.h">
-		</ClInclude>
-		<ClCompile Include="..\..\PhysXVehicle\src\PxVehicleComponents.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\PxVehicleDrive.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\PxVehicleDrive4W.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\PxVehicleDriveNW.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\PxVehicleDriveTank.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\PxVehicleMetaData.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\PxVehicleNoDrive.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\PxVehicleSDK.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\PxVehicleSerialization.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\PxVehicleSuspWheelTire4.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\PxVehicleTireFriction.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\PxVehicleUpdate.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\PxVehicleWheels.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\VehicleUtilControl.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\VehicleUtilSetup.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\VehicleUtilTelemetry.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\PhysXVehicle\src\PhysXMetaData\include\PxVehicleAutoGeneratedMetaDataObjectNames.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXVehicle\src\PhysXMetaData\include\PxVehicleAutoGeneratedMetaDataObjects.h">
-		</ClInclude>
-		<ClInclude Include="..\..\PhysXVehicle\src\PhysXMetaData\include\PxVehicleMetaDataObjects.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\PhysXVehicle\src\PhysXMetaData\src\PxVehicleAutoGeneratedMetaDataObjects.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\PhysXVehicle\src\PhysXMetaData\src\PxVehicleMetaDataObjects.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{BC4778D3-142F-31D0-46EC-77203F28C874}</ProjectGuid>
+    <RootNamespace>PhysXVehicle</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXVehicle/debug\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>PhysX3VehicleDEBUG</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/vehicle;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include/cloth;./../../../Include;./../../../Include/pvd;./../../../Include/physxprofilesdk;./../../Common/src;./../../PhysXVehicle/src;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXMetaData/core/include;./../../PhysXVehicle/src/PhysXMetaData/include;./../../PvdSDK/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3VehicleDEBUG.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXVehicle/checked\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>PhysX3VehicleCHECKED</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/vehicle;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include/cloth;./../../../Include;./../../../Include/pvd;./../../../Include/physxprofilesdk;./../../Common/src;./../../PhysXVehicle/src;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXMetaData/core/include;./../../PhysXVehicle/src/PhysXMetaData/include;./../../PvdSDK/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3VehicleCHECKED.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXVehicle/profile\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>PhysX3VehiclePROFILE</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/vehicle;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include/cloth;./../../../Include;./../../../Include/pvd;./../../../Include/physxprofilesdk;./../../Common/src;./../../PhysXVehicle/src;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXMetaData/core/include;./../../PhysXVehicle/src/PhysXMetaData/include;./../../PvdSDK/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3VehiclePROFILE.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/PhysXVehicle/release\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>PhysX3Vehicle</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/vehicle;./../../../Include/common;./../../../Include/geometry;./../../../Include/extensions;./../../../Include/cloth;./../../../Include;./../../../Include/pvd;./../../../Include/physxprofilesdk;./../../Common/src;./../../PhysXVehicle/src;./../../PhysXMetaData/extensions/include;./../../PhysXExtensions/src/serialization/Xml;./../../PhysXMetaData/core/include;./../../PhysXVehicle/src/PhysXMetaData/include;./../../PvdSDK/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PhysX3Vehicle.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleComponents.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleDrive.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleDrive4W.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleDriveNW.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleDriveTank.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleNoDrive.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleSDK.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleShaders.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleTireFriction.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleUpdate.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleUtil.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleUtilControl.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleUtilSetup.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleUtilTelemetry.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\Include\vehicle\PxVehicleWheels.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysXVehicle\src\PxVehicleDefaults.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXVehicle\src\PxVehicleLinearMath.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXVehicle\src\PxVehicleSerialization.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXVehicle\src\PxVehicleSuspLimitConstraintShader.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXVehicle\src\PxVehicleSuspWheelTire4.h">
+    </ClInclude>
+    <ClCompile Include="..\..\PhysXVehicle\src\PxVehicleComponents.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\PxVehicleDrive.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\PxVehicleDrive4W.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\PxVehicleDriveNW.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\PxVehicleDriveTank.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\PxVehicleMetaData.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\PxVehicleNoDrive.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\PxVehicleSDK.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\PxVehicleSerialization.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\PxVehicleSuspWheelTire4.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\PxVehicleTireFriction.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\PxVehicleUpdate.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\PxVehicleWheels.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\VehicleUtilControl.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\VehicleUtilSetup.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\VehicleUtilTelemetry.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\PhysXVehicle\src\PhysXMetaData\include\PxVehicleAutoGeneratedMetaDataObjectNames.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXVehicle\src\PhysXMetaData\include\PxVehicleAutoGeneratedMetaDataObjects.h">
+    </ClInclude>
+    <ClInclude Include="..\..\PhysXVehicle\src\PhysXMetaData\include\PxVehicleMetaDataObjects.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\PhysXVehicle\src\PhysXMetaData\src\PxVehicleAutoGeneratedMetaDataObjects.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\PhysXVehicle\src\PhysXMetaData\src\PxVehicleMetaDataObjects.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PhysX_3.4/Source/compiler/vc14win64/SceneQuery.vcxproj
+++ b/PhysX_3.4/Source/compiler/vc14win64/SceneQuery.vcxproj
@@ -1,290 +1,299 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{042DAF3E-FF50-B73C-C9A4-53AC6D3CFCEC}</ProjectGuid>
-		<RootNamespace>SceneQuery</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/SceneQuery/debug\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)DEBUG</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SceneQuery/include;./../../SimulationController/include;./../../LowLevel/API/include;./../../PhysX/src;./../../PhysX/src/buffering;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/SceneQuery/checked\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)CHECKED</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SceneQuery/include;./../../SimulationController/include;./../../LowLevel/API/include;./../../PhysX/src;./../../PhysX/src/buffering;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/SceneQuery/profile\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)PROFILE</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SceneQuery/include;./../../SimulationController/include;./../../LowLevel/API/include;./../../PhysX/src;./../../PhysX/src/buffering;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/SceneQuery/release\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SceneQuery/include;./../../SimulationController/include;./../../LowLevel/API/include;./../../PhysX/src;./../../PhysX/src/buffering;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\SceneQuery\src\SqAABBPruner.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SceneQuery\src\SqAABBTree.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SceneQuery\src\SqAABBTreeBuild.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SceneQuery\src\SqAABBTreeUpdateMap.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SceneQuery\src\SqBounds.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SceneQuery\src\SqBucketPruner.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SceneQuery\src\SqExtendedBucketPruner.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SceneQuery\src\SqIncrementalAABBPrunerCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SceneQuery\src\SqIncrementalAABBTree.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SceneQuery\src\SqMetaData.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SceneQuery\src\SqPruningPool.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SceneQuery\src\SqPruningStructure.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SceneQuery\src\SqSceneQueryManager.cpp">
-		</ClCompile>
-		<ClInclude Include="..\..\SceneQuery\src\SqAABBPruner.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\src\SqAABBTree.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\src\SqAABBTreeBuild.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\src\SqAABBTreeQuery.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\src\SqAABBTreeUpdateMap.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\src\SqBounds.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\src\SqBucketPruner.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\src\SqExtendedBucketPruner.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\src\SqIncrementalAABBPrunerCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\src\SqIncrementalAABBTree.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\src\SqPrunerTestsSIMD.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\src\SqPruningPool.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\src\SqTypedef.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\SceneQuery\include\SqPruner.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\include\SqPrunerMergeData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\include\SqPruningStructure.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SceneQuery\include\SqSceneQueryManager.h">
-		</ClInclude>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{042DAF3E-FF50-B73C-C9A4-53AC6D3CFCEC}</ProjectGuid>
+    <RootNamespace>SceneQuery</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/SceneQuery/debug\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)DEBUG</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SceneQuery/include;./../../SimulationController/include;./../../LowLevel/API/include;./../../PhysX/src;./../../PhysX/src/buffering;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/SceneQuery/checked\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)CHECKED</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SceneQuery/include;./../../SimulationController/include;./../../LowLevel/API/include;./../../PhysX/src;./../../PhysX/src/buffering;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/SceneQuery/profile\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)PROFILE</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SceneQuery/include;./../../SimulationController/include;./../../LowLevel/API/include;./../../PhysX/src;./../../PhysX/src/buffering;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/SceneQuery/release\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../../Externals/nvToolsExt/1/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SceneQuery/include;./../../SimulationController/include;./../../LowLevel/API/include;./../../PhysX/src;./../../PhysX/src/buffering;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\SceneQuery\src\SqAABBPruner.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SceneQuery\src\SqAABBTree.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SceneQuery\src\SqAABBTreeBuild.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SceneQuery\src\SqAABBTreeUpdateMap.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SceneQuery\src\SqBounds.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SceneQuery\src\SqBucketPruner.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SceneQuery\src\SqExtendedBucketPruner.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SceneQuery\src\SqIncrementalAABBPrunerCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SceneQuery\src\SqIncrementalAABBTree.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SceneQuery\src\SqMetaData.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SceneQuery\src\SqPruningPool.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SceneQuery\src\SqPruningStructure.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SceneQuery\src\SqSceneQueryManager.cpp">
+    </ClCompile>
+    <ClInclude Include="..\..\SceneQuery\src\SqAABBPruner.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\src\SqAABBTree.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\src\SqAABBTreeBuild.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\src\SqAABBTreeQuery.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\src\SqAABBTreeUpdateMap.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\src\SqBounds.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\src\SqBucketPruner.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\src\SqExtendedBucketPruner.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\src\SqIncrementalAABBPrunerCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\src\SqIncrementalAABBTree.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\src\SqPrunerTestsSIMD.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\src\SqPruningPool.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\src\SqTypedef.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\SceneQuery\include\SqPruner.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\include\SqPrunerMergeData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\include\SqPruningStructure.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SceneQuery\include\SqSceneQueryManager.h">
+    </ClInclude>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PhysX_3.4/Source/compiler/vc14win64/SimulationController.vcxproj
+++ b/PhysX_3.4/Source/compiler/vc14win64/SimulationController.vcxproj
@@ -1,428 +1,437 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{49C560C2-F59E-0A40-E1D5-E0F25960F1AB}</ProjectGuid>
-		<RootNamespace>SimulationController</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/SimulationController/debug\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)DEBUG</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../SimulationController/src/cloth;./../../LowLevel/windows/include;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevelCloth/include;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelParticles/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/SimulationController/checked\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)CHECKED</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../SimulationController/src/cloth;./../../LowLevel/windows/include;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevelCloth/include;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelParticles/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/SimulationController/profile\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)PROFILE</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../SimulationController/src/cloth;./../../LowLevel/windows/include;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevelCloth/include;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelParticles/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../Lib/vc14win64\</OutDir>
-		<IntDir>./x64/SimulationController/release\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../SimulationController/src/cloth;./../../LowLevel/windows/include;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevelCloth/include;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelParticles/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\SimulationController\include\ScActorCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScArticulationCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScArticulationJointCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScBodyCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScClothCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScClothFabricCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScConstraintCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScIterators.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScMaterialCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScParticleSystemCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScPhysics.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScRigidCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScScene.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScShapeCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\include\ScStaticCore.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\SimulationController\src\particles\ScParticleBodyInteraction.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\particles\ScParticlePacketShape.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\particles\ScParticleSystemSim.h">
-		</ClInclude>
-		<ClCompile Include="..\..\SimulationController\src\particles\ScParticleBodyInteraction.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\particles\ScParticlePacketShape.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\particles\ScParticleSystemCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\particles\ScParticleSystemSim.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\SimulationController\src\cloth\ScClothShape.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\cloth\ScClothSim.h">
-		</ClInclude>
-		<ClCompile Include="..\..\SimulationController\src\cloth\ScClothCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\cloth\ScClothFabricCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\cloth\ScClothShape.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\cloth\ScClothSim.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\SimulationController\src\ScActorElementPair.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScActorInteraction.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScActorPair.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScActorSim.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScArticulationJointSim.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScArticulationSim.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScBodySim.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScClient.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScConstraintGroupNode.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScConstraintInteraction.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScConstraintProjectionManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScConstraintProjectionTree.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScConstraintSim.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScContactReportBuffer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScContactStream.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScElementInteractionMarker.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScElementSim.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScElementSimInteraction.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScInteraction.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScInteractionFlags.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScNPhaseCore.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScObjectIDTracker.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScRbElementInteraction.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScRigidSim.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScShapeInteraction.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScShapeIterator.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScShapeSim.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScSimStateData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScSimStats.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScSimulationController.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScSqBoundsManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScStaticSim.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScTriggerInteraction.h">
-		</ClInclude>
-		<ClInclude Include="..\..\SimulationController\src\ScTriggerPairs.h">
-		</ClInclude>
-		<ClCompile Include="..\..\SimulationController\src\ScActorCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScActorSim.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScArticulationCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScArticulationJointCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScArticulationJointSim.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScArticulationSim.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScBodyCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScBodyCoreKinematic.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScBodySim.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScConstraintCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScConstraintGroupNode.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScConstraintInteraction.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScConstraintProjectionManager.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScConstraintProjectionTree.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScConstraintSim.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScElementInteractionMarker.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScElementSim.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScInteraction.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScIterators.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScMaterialCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScMetaData.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScNPhaseCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScPhysics.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScRigidCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScRigidSim.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScScene.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScShapeCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScShapeInteraction.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScShapeSim.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScSimStats.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScSimulationController.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScSqBoundsManager.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScStaticCore.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScStaticSim.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\SimulationController\src\ScTriggerInteraction.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{49C560C2-F59E-0A40-E1D5-E0F25960F1AB}</ProjectGuid>
+    <RootNamespace>SimulationController</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/SimulationController/debug\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)DEBUG</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../SimulationController/src/cloth;./../../LowLevel/windows/include;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevelCloth/include;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelParticles/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)DEBUG.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/SimulationController/checked\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)CHECKED</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../SimulationController/src/cloth;./../../LowLevel/windows/include;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevelCloth/include;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelParticles/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_CHECKED=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)CHECKED.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/SimulationController/profile\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)PROFILE</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../SimulationController/src/cloth;./../../LowLevel/windows/include;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevelCloth/include;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelParticles/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_PROFILE=1;PX_NVTX=1;PX_SUPPORT_PVD=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)PROFILE.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../Lib/vc14win64\</OutDir>
+    <IntDir>./x64/SimulationController/release\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4435 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../PhysXGpu/include;./../../Common/include;./../../../../PxShared/include;./../../../../PxShared/src/foundation/include;./../../../../PxShared/src/fastxml/include;./../../../../PxShared/src/pvd/include;./../../../Include/common;./../../../Include/geometry;./../../../Include/GeomUtils;./../../../Include/pvd;./../../../Include/particles;./../../../Include/cloth;./../../../Include;./../../Common/src;./../../Common/src/windows;./../../GeomUtils/headers;./../../GeomUtils/src;./../../GeomUtils/src/contact;./../../GeomUtils/src/common;./../../GeomUtils/src/convex;./../../GeomUtils/src/distance;./../../GeomUtils/src/sweep;./../../GeomUtils/src/gjk;./../../GeomUtils/src/intersection;./../../GeomUtils/src/mesh;./../../GeomUtils/src/hf;./../../GeomUtils/src/pcm;./../../GeomUtils/src/ccd;./../../SimulationController/include;./../../SimulationController/src;./../../SimulationController/src/particles;./../../SimulationController/src/cloth;./../../LowLevel/windows/include;./../../LowLevel/API/include;./../../LowLevel/software/include;./../../LowLevel/common/include/math;./../../LowLevel/common/include/utils;./../../LowLevel/common/include/collision;./../../LowLevel/common/include/pipeline;./../../LowLevelCloth/include;./../../LowLevelAABB/include;./../../LowLevelDynamics/include;./../../LowLevelParticles/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PHYSX_STATIC_LIB;NDEBUG;PX_SUPPORT_PVD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName).lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\SimulationController\include\ScActorCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScArticulationCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScArticulationJointCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScBodyCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScClothCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScClothFabricCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScConstraintCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScIterators.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScMaterialCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScParticleSystemCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScPhysics.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScRigidCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScScene.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScShapeCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\include\ScStaticCore.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\SimulationController\src\particles\ScParticleBodyInteraction.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\particles\ScParticlePacketShape.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\particles\ScParticleSystemSim.h">
+    </ClInclude>
+    <ClCompile Include="..\..\SimulationController\src\particles\ScParticleBodyInteraction.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\particles\ScParticlePacketShape.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\particles\ScParticleSystemCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\particles\ScParticleSystemSim.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\SimulationController\src\cloth\ScClothShape.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\cloth\ScClothSim.h">
+    </ClInclude>
+    <ClCompile Include="..\..\SimulationController\src\cloth\ScClothCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\cloth\ScClothFabricCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\cloth\ScClothShape.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\cloth\ScClothSim.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\SimulationController\src\ScActorElementPair.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScActorInteraction.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScActorPair.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScActorSim.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScArticulationJointSim.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScArticulationSim.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScBodySim.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScClient.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScConstraintGroupNode.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScConstraintInteraction.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScConstraintProjectionManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScConstraintProjectionTree.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScConstraintSim.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScContactReportBuffer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScContactStream.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScElementInteractionMarker.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScElementSim.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScElementSimInteraction.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScInteraction.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScInteractionFlags.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScNPhaseCore.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScObjectIDTracker.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScRbElementInteraction.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScRigidSim.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScShapeInteraction.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScShapeIterator.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScShapeSim.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScSimStateData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScSimStats.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScSimulationController.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScSqBoundsManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScStaticSim.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScTriggerInteraction.h">
+    </ClInclude>
+    <ClInclude Include="..\..\SimulationController\src\ScTriggerPairs.h">
+    </ClInclude>
+    <ClCompile Include="..\..\SimulationController\src\ScActorCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScActorSim.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScArticulationCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScArticulationJointCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScArticulationJointSim.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScArticulationSim.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScBodyCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScBodyCoreKinematic.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScBodySim.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScConstraintCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScConstraintGroupNode.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScConstraintInteraction.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScConstraintProjectionManager.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScConstraintProjectionTree.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScConstraintSim.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScElementInteractionMarker.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScElementSim.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScInteraction.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScIterators.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScMaterialCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScMetaData.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScNPhaseCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScPhysics.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScRigidCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScRigidSim.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScScene.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScShapeCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScShapeInteraction.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScShapeSim.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScSimStats.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScSimulationController.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScSqBoundsManager.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScStaticCore.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScStaticSim.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\SimulationController\src\ScTriggerInteraction.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PxShared/src/compiler/vc14win64/PsFastXml.vcxproj
+++ b/PxShared/src/compiler/vc14win64/PsFastXml.vcxproj
@@ -1,234 +1,243 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{82276A9F-CCF0-C50C-BB4A-82ACFFE2A93A}</ProjectGuid>
-		<RootNamespace>PsFastXml</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../lib/vc14win64\</OutDir>
-		<IntDir>./x64/PsFastXml/debug\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)DEBUG_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;./../../foundation/include;./../../fastxml/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_FOUNDATION_DLL=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)DEBUG_x64.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../lib/vc14win64\</OutDir>
-		<IntDir>./x64/PsFastXml/release\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;./../../foundation/include;./../../fastxml/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_FOUNDATION_DLL=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)_x64.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../lib/vc14win64\</OutDir>
-		<IntDir>./x64/PsFastXml/checked\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)CHECKED_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;./../../foundation/include;./../../fastxml/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_FOUNDATION_DLL=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)CHECKED_x64.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../lib/vc14win64\</OutDir>
-		<IntDir>./x64/PsFastXml/profile\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)PROFILE_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;./../../foundation/include;./../../fastxml/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_FOUNDATION_DLL=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_PROFILE=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)PROFILE_x64.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\fastxml\include\PsFastXml.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\fastxml\src\PsFastXml.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{82276A9F-CCF0-C50C-BB4A-82ACFFE2A93A}</ProjectGuid>
+    <RootNamespace>PsFastXml</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../lib/vc14win64\</OutDir>
+    <IntDir>./x64/PsFastXml/debug\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)DEBUG_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;./../../foundation/include;./../../fastxml/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_FOUNDATION_DLL=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)DEBUG_x64.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../lib/vc14win64\</OutDir>
+    <IntDir>./x64/PsFastXml/release\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;./../../foundation/include;./../../fastxml/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_FOUNDATION_DLL=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)_x64.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../lib/vc14win64\</OutDir>
+    <IntDir>./x64/PsFastXml/checked\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)CHECKED_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;./../../foundation/include;./../../fastxml/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_FOUNDATION_DLL=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)CHECKED_x64.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../lib/vc14win64\</OutDir>
+    <IntDir>./x64/PsFastXml/profile\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)PROFILE_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;./../../foundation/include;./../../fastxml/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_FOUNDATION_DLL=0;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_PROFILE=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)PROFILE_x64.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\fastxml\include\PsFastXml.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\fastxml\src\PsFastXml.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PxShared/src/compiler/vc14win64/PxFoundation.vcxproj
+++ b/PxShared/src/compiler/vc14win64/PxFoundation.vcxproj
@@ -1,448 +1,460 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{DF4537B3-3CE9-1581-10B6-A291FE3299C6}</ProjectGuid>
-		<RootNamespace>PxFoundation</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PxFoundation/debug\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PxFoundationDEBUG_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;$(WindowsSDK_IncludePath);./../../foundation/include;./../../foundation/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PxFoundationDEBUG_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PxFoundation/release\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PxFoundation_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;$(WindowsSDK_IncludePath);./../../foundation/include;./../../foundation/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PxFoundation_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PxFoundation/checked\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PxFoundationCHECKED_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;$(WindowsSDK_IncludePath);./../../foundation/include;./../../foundation/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PxFoundationCHECKED_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PxFoundation/profile\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PxFoundationPROFILE_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;$(WindowsSDK_IncludePath);./../../foundation/include;./../../foundation/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_PROFILE=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PxFoundationPROFILE_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ResourceCompile Include="..\resource_x64\PxFoundation.rc">
-		</ResourceCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\include\foundation\windows\PxWindowsFoundationDelayLoadHook.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\windows\PxWindowsIntrinsics.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\include\foundation\Px.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxAllocatorCallback.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxAssert.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxBitAndData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxBounds3.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxErrorCallback.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxErrors.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxFlags.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxFoundation.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxFoundationVersion.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxIntrinsics.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxIO.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxMat33.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxMat44.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxMath.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxMathUtils.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxMemory.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxPlane.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxPreprocessor.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxProfiler.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxQuat.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxSimpleTypes.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxStrideIterator.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxTransform.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxUnionCast.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxVec2.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxVec3.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\foundation\PxVec4.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\foundation\include\windows\PsWindowsAoS.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\windows\PsWindowsFPU.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\windows\PsWindowsInclude.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\windows\PsWindowsInlineAoS.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\windows\PsWindowsIntrinsics.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\windows\PsWindowsLoadLibrary.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\windows\PsWindowsTrigConstants.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\foundation\include\Ps.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsAlignedMalloc.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsAlloca.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsAllocator.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsAoS.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsArray.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsAtomic.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsBasicTemplates.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsBitUtils.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsBroadcast.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsCpu.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsFoundation.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsFPU.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsHash.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsHashInternals.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsHashMap.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsHashSet.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsInlineAllocator.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsInlineAoS.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsInlineArray.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsIntrinsics.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsMathUtils.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsMutex.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsPool.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsSList.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsSocket.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsSort.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsSortInternals.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsString.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsSync.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsTempAllocator.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsThread.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsTime.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsUserAllocated.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsUtilities.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsVecMath.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsVecMathAoSScalar.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsVecMathAoSScalarInline.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsVecMathSSE.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsVecMathUtilities.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsVecQuat.h">
-		</ClInclude>
-		<ClInclude Include="..\..\foundation\include\PsVecTransform.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\foundation\src\windows\PsWindowsAtomic.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\windows\PsWindowsCpu.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\windows\PsWindowsFPU.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\windows\PsWindowsMutex.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\windows\PsWindowsPrintString.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\windows\PsWindowsSList.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\windows\PsWindowsSocket.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\windows\PsWindowsSync.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\windows\PsWindowsThread.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\windows\PsWindowsTime.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\foundation\src\PsAllocator.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\PsAssert.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\PsFoundation.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\PsMathUtils.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\PsString.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\PsTempAllocator.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\foundation\src\PsUtilities.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{DF4537B3-3CE9-1581-10B6-A291FE3299C6}</ProjectGuid>
+    <RootNamespace>PxFoundation</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PxFoundation/debug\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PxFoundationDEBUG_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;$(WindowsSDK_IncludePath);./../../foundation/include;./../../foundation/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PxFoundationDEBUG_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PxFoundation/release\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PxFoundation_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;$(WindowsSDK_IncludePath);./../../foundation/include;./../../foundation/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PxFoundation_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PxFoundation/checked\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PxFoundationCHECKED_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;$(WindowsSDK_IncludePath);./../../foundation/include;./../../foundation/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PxFoundationCHECKED_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PxFoundation/profile\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PxFoundationPROFILE_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;$(WindowsSDK_IncludePath);./../../foundation/include;./../../foundation/include/windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PX_FOUNDATION_DLL=1;WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_PROFILE=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PxFoundationPROFILE_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\resource_x64\PxFoundation.rc">
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\include\foundation\windows\PxWindowsFoundationDelayLoadHook.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\windows\PxWindowsIntrinsics.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\include\foundation\Px.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxAllocatorCallback.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxAssert.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxBitAndData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxBounds3.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxErrorCallback.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxErrors.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxFlags.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxFoundation.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxFoundationVersion.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxIntrinsics.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxIO.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxMat33.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxMat44.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxMath.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxMathUtils.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxMemory.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxPlane.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxPreprocessor.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxProfiler.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxQuat.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxSimpleTypes.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxStrideIterator.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxTransform.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxUnionCast.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxVec2.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxVec3.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\foundation\PxVec4.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\foundation\include\windows\PsWindowsAoS.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\windows\PsWindowsFPU.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\windows\PsWindowsInclude.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\windows\PsWindowsInlineAoS.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\windows\PsWindowsIntrinsics.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\windows\PsWindowsLoadLibrary.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\windows\PsWindowsTrigConstants.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\foundation\include\Ps.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsAlignedMalloc.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsAlloca.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsAllocator.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsAoS.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsArray.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsAtomic.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsBasicTemplates.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsBitUtils.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsBroadcast.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsCpu.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsFoundation.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsFPU.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsHash.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsHashInternals.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsHashMap.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsHashSet.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsInlineAllocator.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsInlineAoS.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsInlineArray.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsIntrinsics.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsMathUtils.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsMutex.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsPool.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsSList.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsSocket.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsSort.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsSortInternals.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsString.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsSync.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsTempAllocator.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsThread.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsTime.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsUserAllocated.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsUtilities.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsVecMath.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsVecMathAoSScalar.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsVecMathAoSScalarInline.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsVecMathSSE.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsVecMathUtilities.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsVecQuat.h">
+    </ClInclude>
+    <ClInclude Include="..\..\foundation\include\PsVecTransform.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\foundation\src\windows\PsWindowsAtomic.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\windows\PsWindowsCpu.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\windows\PsWindowsFPU.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\windows\PsWindowsMutex.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\windows\PsWindowsPrintString.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\windows\PsWindowsSList.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\windows\PsWindowsSocket.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\windows\PsWindowsSync.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\windows\PsWindowsThread.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\windows\PsWindowsTime.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\foundation\src\PsAllocator.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\PsAssert.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\PsFoundation.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\PsMathUtils.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\PsString.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\PsTempAllocator.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\foundation\src\PsUtilities.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PxShared/src/compiler/vc14win64/PxPvdSDK.vcxproj
+++ b/PxShared/src/compiler/vc14win64/PxPvdSDK.vcxproj
@@ -1,421 +1,433 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{D4255C0E-3C6E-8A94-959C-54BAC884B25C}</ProjectGuid>
-		<RootNamespace>PxPvdSDK</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PxPvdSDK/debug\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PxPvdSDKDEBUG_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;./../../pvd/include;./../../foundation/include;./../../filebuf/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PVDSDK_DLL=1;PX_FOUNDATION_DLL=1;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/DELAYLOAD:PxFoundationDEBUG_x64.dll</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PxPvdSDKDEBUG_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PxPvdSDK/release\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PxPvdSDK_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;./../../pvd/include;./../../foundation/include;./../../filebuf/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PVDSDK_DLL=1;PX_FOUNDATION_DLL=1;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/INCREMENTAL:NO /DELAYLOAD:PxFoundation_x64.dll</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PxPvdSDK_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PxPvdSDK/checked\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PxPvdSDKCHECKED_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;./../../pvd/include;./../../foundation/include;./../../filebuf/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PVDSDK_DLL=1;PX_FOUNDATION_DLL=1;NDEBUG;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/DELAYLOAD:PxFoundationCHECKED_x64.dll</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PxPvdSDKCHECKED_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../bin/vc14win64\</OutDir>
-		<IntDir>./x64/PxPvdSDK/profile\</IntDir>
-		<TargetExt>.dll</TargetExt>
-		<TargetName>PxPvdSDKPROFILE_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-		<SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;./../../pvd/include;./../../foundation/include;./../../filebuf/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PVDSDK_DLL=1;PX_FOUNDATION_DLL=1;NDEBUG;PX_PROFILE=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Link>
-			<AdditionalOptions>/INCREMENTAL:NO /DELAYLOAD:PxFoundationPROFILE_x64.dll</AdditionalOptions>
-			<AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)PxPvdSDKPROFILE_x64.dll</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Link>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ResourceCompile Include="..\resource_x64\PxPvdSDK.rc">
-		</ResourceCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\include\pvd\windows\PxWindowsPvdDelayLoadHook.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\include\pvd\PxPvd.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\pvd\PxPvdTransport.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\pvd\include\PsPvd.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\include\PxProfileAllocatorWrapper.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\include\PxPvdClient.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\include\PxPvdDataStream.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\include\PxPvdDataStreamHelpers.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\include\PxPvdErrorCodes.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\include\PxPvdObjectModelBaseTypes.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\include\PxPvdRenderBuffer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\include\PxPvdUserRenderer.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\pvd\src\windows\PxWindowsPvdDelayLoadHook.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\pvd\src\PxProfileEventImpl.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\pvd\src\PxPvd.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\pvd\src\PxPvdDataStream.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\pvd\src\PxPvdDefaultFileTransport.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\pvd\src\PxPvdDefaultSocketTransport.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\pvd\src\PxPvdImpl.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\pvd\src\PxPvdMemClient.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\pvd\src\PxPvdObjectModelMetaData.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\pvd\src\PxPvdObjectRegistrar.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\pvd\src\PxPvdProfileZoneClient.cpp">
-		</ClCompile>
-		<ClCompile Include="..\..\pvd\src\PxPvdUserRenderer.cpp">
-		</ClCompile>
-		<ClInclude Include="..\..\pvd\src\PxProfileBase.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileCompileTimeEventFilter.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileContextProvider.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileContextProviderImpl.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileDataBuffer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileDataParsing.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEventBuffer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEventBufferAtomic.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEventBufferClient.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEventBufferClientManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEventFilter.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEventHandler.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEventId.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEventMutex.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEventNames.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEventParser.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEvents.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEventSender.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEventSerialization.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileEventSystem.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileMemory.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileMemoryBuffer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileMemoryEventBuffer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileMemoryEventParser.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileMemoryEventRecorder.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileMemoryEventReflexiveWriter.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileMemoryEvents.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileMemoryEventSummarizer.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileMemoryEventTypes.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileScopedEvent.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileScopedMutexLock.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileZone.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileZoneImpl.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileZoneManager.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxProfileZoneManagerImpl.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdBits.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdByteStreams.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdCommStreamEvents.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdCommStreamEventSink.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdCommStreamSDKEventTypes.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdCommStreamTypes.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdDefaultFileTransport.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdDefaultSocketTransport.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdFoundation.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdImpl.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdInternalByteStreams.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdMarshalling.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdMemClient.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdObjectModel.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdObjectModelInternalTypeDefs.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdObjectModelInternalTypes.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdObjectModelMetaData.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdObjectRegistrar.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdProfileZoneClient.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdUserRenderImpl.h">
-		</ClInclude>
-		<ClInclude Include="..\..\pvd\src\PxPvdUserRenderTypes.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="./PxFoundation.vcxproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{D4255C0E-3C6E-8A94-959C-54BAC884B25C}</ProjectGuid>
+    <RootNamespace>PxPvdSDK</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PxPvdSDK/debug\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PxPvdSDKDEBUG_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;./../../pvd/include;./../../foundation/include;./../../filebuf/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PVDSDK_DLL=1;PX_FOUNDATION_DLL=1;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/DELAYLOAD:PxFoundationDEBUG_x64.dll</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PxPvdSDKDEBUG_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PxPvdSDK/release\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PxPvdSDK_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;./../../pvd/include;./../../foundation/include;./../../filebuf/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PVDSDK_DLL=1;PX_FOUNDATION_DLL=1;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/INCREMENTAL:NO /DELAYLOAD:PxFoundation_x64.dll</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PxPvdSDK_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PxPvdSDK/checked\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PxPvdSDKCHECKED_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;./../../pvd/include;./../../foundation/include;./../../filebuf/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PVDSDK_DLL=1;PX_FOUNDATION_DLL=1;NDEBUG;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/DELAYLOAD:PxFoundationCHECKED_x64.dll</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PxPvdSDKCHECKED_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../bin/vc14win64\</OutDir>
+    <IntDir>./x64/PxPvdSDK/profile\</IntDir>
+    <TargetExt>.dll</TargetExt>
+    <TargetName>PxPvdSDKPROFILE_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <SkipCopyingSymbolsToOutputDirectory>true</SkipCopyingSymbolsToOutputDirectory>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;./../../pvd/include;./../../foundation/include;./../../filebuf/include;./../../../../Externals/nvToolsExt/1/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;PX_PVDSDK_DLL=1;PX_FOUNDATION_DLL=1;NDEBUG;PX_PROFILE=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/INCREMENTAL:NO /DELAYLOAD:PxFoundationPROFILE_x64.dll</AdditionalOptions>
+      <AdditionalDependencies>./../../../../Externals/nvToolsExt/1/lib/x64/nvToolsExt64_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)PxPvdSDKPROFILE_x64.dll</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <ImportLibrary>./../../../lib/vc14win64/$(TargetName).lib</ImportLibrary>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\resource_x64\PxPvdSDK.rc">
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\include\pvd\windows\PxWindowsPvdDelayLoadHook.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\include\pvd\PxPvd.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\pvd\PxPvdTransport.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\pvd\include\PsPvd.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\include\PxProfileAllocatorWrapper.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\include\PxPvdClient.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\include\PxPvdDataStream.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\include\PxPvdDataStreamHelpers.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\include\PxPvdErrorCodes.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\include\PxPvdObjectModelBaseTypes.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\include\PxPvdRenderBuffer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\include\PxPvdUserRenderer.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\pvd\src\windows\PxWindowsPvdDelayLoadHook.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\pvd\src\PxProfileEventImpl.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\pvd\src\PxPvd.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\pvd\src\PxPvdDataStream.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\pvd\src\PxPvdDefaultFileTransport.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\pvd\src\PxPvdDefaultSocketTransport.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\pvd\src\PxPvdImpl.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\pvd\src\PxPvdMemClient.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\pvd\src\PxPvdObjectModelMetaData.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\pvd\src\PxPvdObjectRegistrar.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\pvd\src\PxPvdProfileZoneClient.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\pvd\src\PxPvdUserRenderer.cpp">
+    </ClCompile>
+    <ClInclude Include="..\..\pvd\src\PxProfileBase.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileCompileTimeEventFilter.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileContextProvider.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileContextProviderImpl.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileDataBuffer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileDataParsing.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEventBuffer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEventBufferAtomic.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEventBufferClient.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEventBufferClientManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEventFilter.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEventHandler.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEventId.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEventMutex.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEventNames.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEventParser.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEvents.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEventSender.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEventSerialization.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileEventSystem.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileMemory.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileMemoryBuffer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileMemoryEventBuffer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileMemoryEventParser.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileMemoryEventRecorder.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileMemoryEventReflexiveWriter.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileMemoryEvents.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileMemoryEventSummarizer.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileMemoryEventTypes.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileScopedEvent.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileScopedMutexLock.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileZone.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileZoneImpl.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileZoneManager.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxProfileZoneManagerImpl.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdBits.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdByteStreams.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdCommStreamEvents.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdCommStreamEventSink.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdCommStreamSDKEventTypes.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdCommStreamTypes.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdDefaultFileTransport.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdDefaultSocketTransport.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdFoundation.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdImpl.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdInternalByteStreams.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdMarshalling.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdMemClient.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdObjectModel.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdObjectModelInternalTypeDefs.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdObjectModelInternalTypes.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdObjectModelMetaData.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdObjectRegistrar.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdProfileZoneClient.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdUserRenderImpl.h">
+    </ClInclude>
+    <ClInclude Include="..\..\pvd\src\PxPvdUserRenderTypes.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="./PxFoundation.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/PxShared/src/compiler/vc14win64/PxTask.vcxproj
+++ b/PxShared/src/compiler/vc14win64/PxTask.vcxproj
@@ -1,246 +1,255 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="debug|x64">
-			<Configuration>debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="release|x64">
-			<Configuration>release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="checked|x64">
-			<Configuration>checked</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="profile|x64">
-			<Configuration>profile</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{5B1132F6-84F8-142E-B951-ADB8505CC27F}</ProjectGuid>
-		<RootNamespace>PxTask</RootNamespace>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<OutDir>./../../../lib/vc14win64\</OutDir>
-		<IntDir>./x64/PxTask/debug\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)DEBUG_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;./../../task/include;./../../foundation/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)DEBUG_x64.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<OutDir>./../../../lib/vc14win64\</OutDir>
-		<IntDir>./x64/PxTask/release\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;./../../task/include;./../../foundation/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)_x64.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<OutDir>./../../../lib/vc14win64\</OutDir>
-		<IntDir>./x64/PxTask/checked\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)CHECKED_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;./../../task/include;./../../foundation/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)CHECKED_x64.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<OutDir>./../../../lib/vc14win64\</OutDir>
-		<IntDir>./x64/PxTask/profile\</IntDir>
-		<TargetExt>.lib</TargetExt>
-		<TargetName>$(ProjectName)PROFILE_x64</TargetName>
-		<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-		<CodeAnalysisRules />
-		<CodeAnalysisRuleAssemblies />
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
-		<ClCompile>
-			<TreatWarningAsError>true</TreatWarningAsError>
-			<StringPooling>true</StringPooling>
-			<RuntimeTypeInfo>false</RuntimeTypeInfo>
-			<BufferSecurityCheck>false</BufferSecurityCheck>
-			<FloatingPointModel>Fast</FloatingPointModel>
-			<AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
-			<Optimization>Full</Optimization>
-			<AdditionalIncludeDirectories>./../../../include;./../../task/include;./../../foundation/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_PROFILE=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ExceptionHandling>false</ExceptionHandling>
-			<WarningLevel>Level4</WarningLevel>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<PrecompiledHeaderFile></PrecompiledHeaderFile>
-			<ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
-			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-		</ClCompile>
-		<Lib>
-			<AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
-			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-			<OutputFile>$(OutDir)$(ProjectName)PROFILE_x64.lib</OutputFile>
-			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-			<ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
-			<TargetMachine>MachineX64</TargetMachine>
-		</Lib>
-		<ResourceCompile>
-		</ResourceCompile>
-		<ProjectReference>
-			<LinkLibraryDependencies>true</LinkLibraryDependencies>
-		</ProjectReference>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\include\task\PxCpuDispatcher.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\task\PxGpuDispatcher.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\task\PxGpuTask.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\task\PxTask.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\task\PxTaskDefine.h">
-		</ClInclude>
-		<ClInclude Include="..\..\..\include\task\PxTaskManager.h">
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\task\src\TaskManager.cpp">
-		</ClCompile>
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<ImportGroup Label="ExtensionTargets"></ImportGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="debug|x64">
+      <Configuration>debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="release|x64">
+      <Configuration>release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="checked|x64">
+      <Configuration>checked</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="profile|x64">
+      <Configuration>profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{5B1132F6-84F8-142E-B951-ADB8505CC27F}</ProjectGuid>
+    <RootNamespace>PxTask</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <OutDir>./../../../lib/vc14win64\</OutDir>
+    <IntDir>./x64/PxTask/debug\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)DEBUG_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;./../../task/include;./../../foundation/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;PX_DEBUG=1;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)DEBUG_x64.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <OutDir>./../../../lib/vc14win64\</OutDir>
+    <IntDir>./x64/PxTask/release\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+ /Gw</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;./../../task/include;./../../foundation/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)_x64.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <OutDir>./../../../lib/vc14win64\</OutDir>
+    <IntDir>./x64/PxTask/checked\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)CHECKED_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='checked|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;./../../task/include;./../../foundation/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_CHECKED=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)CHECKED_x64.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <OutDir>./../../../lib/vc14win64\</OutDir>
+    <IntDir>./x64/PxTask/profile\</IntDir>
+    <TargetExt>.lib</TargetExt>
+    <TargetName>$(ProjectName)PROFILE_x64</TargetName>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='profile|x64'">
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <AdditionalOptions>/MP /Wall /wd4514 /wd4820 /wd4127 /wd4710 /wd4711 /wd4577 /wd4464 /d2Zi+</AdditionalOptions>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>./../../../include;./../../task/include;./../../foundation/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN64;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;NDEBUG;PX_PROFILE=1;PX_NVTX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>false</ExceptionHandling>
+      <WarningLevel>Level4</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <ProgramDataBaseFileName>$(TargetDir)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <AdditionalOptions>/INCREMENTAL:NO</AdditionalOptions>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(ProjectName)PROFILE_x64.lib</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(TargetDir)\$(TargetName).pdb</ProgramDatabaseFile>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ResourceCompile>
+    </ResourceCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\include\task\PxCpuDispatcher.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\task\PxGpuDispatcher.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\task\PxGpuTask.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\task\PxTask.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\task\PxTaskDefine.h">
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\task\PxTaskManager.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\task\src\TaskManager.cpp">
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>


### PR DESCRIPTION
Default compilation flags for Release builds are not optimal, so every time we update PhysX I have to manually fix flags for all target platforms.
This pull request enables Link Time Code Generation and dead code\data elimination for VS2015 x64 target.
It's a partial pull request, if you are willing to accept it - I'll go through every other VS project, will fix flags and whitespaces and will create a new pull request.
The same issue exists in console projects, how do I create pull requests for XB1 and PS4?