### PR TITLE
flushEventIdNameMap:  Missing lock when there are multiple scenes.

### DIFF
--- a/PxShared/src/pvd/src/PxProfileZoneImpl.h
+++ b/PxShared/src/pvd/src/PxProfileZoneImpl.h
@@ -124,6 +124,7 @@ namespace physx { namespace profile {
 
 		virtual void flushEventIdNameMap()
 		{
+			TLockType theLocker(mMutex);
 			// copy the RW map into R map
 			if (mNameToEvtIndexMapRW.size())
 			{


### PR DESCRIPTION
Missing lock when there are multiple scenes.